### PR TITLE
refactor(puniyu_macros):重构宏实现以支持新的钩子系统

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1886,19 +1886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
-]
-
-[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,8 +2338,15 @@ dependencies = [
 name = "puniyu_macros"
 version = "0.8.1"
 dependencies = [
+ "convert_case 0.11.0",
  "croner",
- "zyn",
+ "proc-macro2",
+ "puniyu_adapter",
+ "puniyu_context",
+ "puniyu_plugin",
+ "quote",
+ "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -2636,7 +2630,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2836,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3042,6 +3036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,7 +3051,16 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3263,6 +3272,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -3570,7 +3594,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4068,12 +4092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,36 +4233,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zyn"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4cc63a0258eef63faf98127747922c45d2770ab9f918602d90307bddc469fe"
-dependencies = [
- "zyn-core",
- "zyn-derive",
-]
-
-[[package]]
-name = "zyn-core"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552fd5767f6237d861274b24c74dcba5135dd02483c2c9e94ebf773dd8580979"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zyn-derive"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948da9db2c8273346a62e650afd5b133ba4e8d1dc4eb1bed1e3c0de24d00243"
-dependencies = [
- "zyn-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ dependencies = [
  "puniyu_context",
  "puniyu_plugin",
  "quote",
+ "serde",
  "syn",
  "trybuild",
 ]

--- a/crates/puniyu_adapter/src/context.rs
+++ b/crates/puniyu_adapter/src/context.rs
@@ -1,0 +1,1 @@
+pub use puniyu_api::context::*;

--- a/crates/puniyu_adapter/src/lib.rs
+++ b/crates/puniyu_adapter/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod bot;
 pub mod contact;
+pub mod context;
 pub mod element;
 pub mod event;
 pub mod hook;

--- a/crates/puniyu_macros/Cargo.toml
+++ b/crates/puniyu_macros/Cargo.toml
@@ -18,10 +18,11 @@ convert_case.workspace = true
 croner.workspace = true
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full", "extra-traits"] }
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 puniyu_adapter.workspace = true
 puniyu_context.workspace = true
 puniyu_plugin.workspace = true
+serde.workspace = true
 trybuild = "1"

--- a/crates/puniyu_macros/Cargo.toml
+++ b/crates/puniyu_macros/Cargo.toml
@@ -14,5 +14,14 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
+convert_case.workspace = true
 croner.workspace = true
-zyn = { version = "0.5.4",  features = ["pretty", "diagnostics"] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+puniyu_adapter.workspace = true
+puniyu_context.workspace = true
+puniyu_plugin.workspace = true
+trybuild = "1"

--- a/crates/puniyu_macros/justfile
+++ b/crates/puniyu_macros/justfile
@@ -1,0 +1,13 @@
+set windows-shell := ["powershell.exe", "-c"]
+set shell := ["bash", "-cu"]
+
+test: update-trybuild
+    cargo test -p puniyu_macros
+
+gen-trybuild:
+    {{ if os_family() == "windows" { "$env:TRYBUILD='overwrite'; cargo test -p puniyu_macros --test trybuild" } else { "TRYBUILD=overwrite cargo test -p puniyu_macros --test trybuild" } }}
+
+accept-trybuild:
+    {{ if os_family() == "windows" { "$files = Get-ChildItem \"wip/*.stderr\" -ErrorAction SilentlyContinue; if (-not $files) { Write-Host \"No trybuild stderr files in wip\"; exit 0 }; foreach ($file in $files) { Copy-Item $file.FullName (Join-Path \"tests/ui\" $file.Name) -Force }; Write-Host \"Accepted $($files.Count) trybuild stderr file(s).\"" } else { "files=wip/*.stderr; if ! ls $files >/dev/null 2>&1; then echo 'No trybuild stderr files in wip'; exit 0; fi; count=0; for file in $files; do cp \"$file\" tests/ui/; count=$((count+1)); done; echo \"Accepted $count trybuild stderr file(s).\"" } }}
+
+update-trybuild: gen-trybuild accept-trybuild

--- a/crates/puniyu_macros/src/adapter.rs
+++ b/crates/puniyu_macros/src/adapter.rs
@@ -5,8 +5,10 @@ pub use hook::hook;
 
 use crate::AdapterArgs;
 use crate::common::{validate_async, validate_return_type};
-use zyn::{ToTokens, zyn};
-pub fn adapter(item: zyn::syn::ItemFn, cfg: AdapterArgs) -> zyn::TokenStream {
+use quote::quote;
+use syn::ItemFn;
+
+pub fn adapter(item: ItemFn, cfg: AdapterArgs) -> proc_macro2::TokenStream {
 	if let Err(err) = validate_async(&item.sig) {
 		return err.to_compile_error();
 	}
@@ -14,73 +16,69 @@ pub fn adapter(item: zyn::syn::ItemFn, cfg: AdapterArgs) -> zyn::TokenStream {
 		return err.to_compile_error();
 	}
 
-	let adapter_name = zyn! { env!("CARGO_PKG_NAME") };
 	let fn_name = &item.sig.ident;
+	let runtime = cfg.runtime;
+	let server_impl = match cfg.server {
+		Some(server) => quote! {
+			fn server(&self) -> Option<::puniyu_adapter::__private::ServerFunction> {
+				Some(::puniyu_adapter::__private::ServerFunction::new(#server))
+			}
+		},
+		None => quote! {},
+	};
 	let init_impl = if item.block.stmts.is_empty() {
-		zyn! {}
+		quote! {}
 	} else {
-		zyn! {
+		quote! {
 			#[inline]
 			async fn init(&self) -> ::puniyu_adapter::Result {
-				{{ fn_name }}().await
+				#fn_name().await
 			}
 		}
 	};
 
-	zyn! {
-		{{ item }}
+	quote! {
+		#item
 
 		pub struct Adapter;
 
 		#[::puniyu_adapter::__private::async_trait]
 		impl ::puniyu_adapter::__private::Adapter for Adapter {
 			fn runtime(&self) -> ::std::sync::Arc<dyn ::puniyu_adapter::runtime::AdapterRuntime> {
-				{{ cfg.runtime }}()
+				#runtime()
 			}
-			fn config(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_adapter::__private::Config>> {
+
+			fn config(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_adapter::__private::Config>> {
 				::puniyu_adapter::__private::inventory::iter::<crate::ConfigRegistry>
 					.into_iter()
-					.filter(|registry| registry.adapter_name == {{ adapter_name}})
+					.filter(|registry| registry.adapter_name == env!("CARGO_PKG_NAME"))
 					.map(|registry| (registry.builder)())
 					.collect()
 			}
 
-			fn hook(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_adapter::__private::Hook>> {
+			fn hook(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_adapter::__private::Hook>> {
 				::puniyu_adapter::__private::inventory::iter::<crate::HookRegistry>
 					.into_iter()
-					.filter(|registry| registry.adapter_name == {{ adapter_name }})
+					.filter(|registry| registry.adapter_name == env!("CARGO_PKG_NAME"))
 					.map(|registry| (registry.builder)())
 					.collect()
 			}
 
-			fn server(&self) -> Option<::puniyu_adapter::__private::ServerFunction> {
-					@if(cfg.server.is_some()){
-						::puniyu_adapter::__private::ServerFunction::new(&cfg.server)
-					}
-					@else{
-						None
-					}
-			}
+			#server_impl
 
-			{{ init_impl }}
+			#init_impl
 		}
 
-		/// 配置注册表
 		pub(crate) struct ConfigRegistry {
 			adapter_name: &'static str,
-			/// 配置构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_adapter::__private::Config>,
 		}
 		::puniyu_adapter::__private::inventory::collect!(crate::ConfigRegistry);
 
-		/// 钩子注册注册表
 		pub(crate) struct HookRegistry {
 			adapter_name: &'static str,
-			/// 钩子构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_adapter::__private::Hook>,
 		}
 		::puniyu_adapter::__private::inventory::collect!(crate::HookRegistry);
-
 	}
-	.to_token_stream()
 }

--- a/crates/puniyu_macros/src/adapter/config.rs
+++ b/crates/puniyu_macros/src/adapter/config.rs
@@ -1,48 +1,38 @@
-use crate::ConfigArgs;
-use zyn::{ToTokens, zyn};
+use crate::{ConfigArgs, common::config_name};
+use quote::quote;
+use syn::ItemStruct;
 
-pub fn config(item: zyn::syn::ItemStruct, cfg: ConfigArgs) -> zyn::TokenStream {
+pub fn config(item: ItemStruct, cfg: ConfigArgs) -> proc_macro2::TokenStream {
 	let struct_name = &item.ident;
-	let config_name = match &cfg.name {
-		Some(name) => zyn! { {{ name | snake | str }}},
-		None => zyn! { {{ struct_name | snake | str }}},
-	};
-	let config_file_name = match &cfg.name {
-		Some(name) => zyn! { {{ name | snake | fmt: "{}.toml" }}},
-		None => zyn! { {{ struct_name | snake | fmt: "{}.toml" }}},
-	};
-	let serialize_error = match &cfg.name {
-		Some(name) => zyn! { {{ name | snake | fmt: "Failed to serialize {} to TOML string" }}},
-		None => zyn! { {{ struct_name | snake | fmt: "Failed to serialize {} to TOML string" }}},
-	};
+	let config_name = config_name(cfg.name.as_deref(), struct_name);
+	let config_file_name = format!("{config_name}.toml");
+	let serialize_error = format!("Failed to serialize {config_name} to TOML string");
 
-	let adapter_name = zyn! { env!("CARGO_PKG_NAME") };
+	quote! {
+		#item
 
-	zyn! {
-		{{ item }}
-
-		impl ::puniyu_adapter::__private::Config for {{ struct_name }} {
+		impl ::puniyu_adapter::__private::Config for #struct_name {
 			fn config(&self) -> ::puniyu_adapter::__private::ConfigInfo {
 				::puniyu_adapter::__private::ConfigInfo {
-					name: ::std::string::String::from({{ config_name }}),
+					name: ::std::string::String::from(#config_name),
 					path: ::puniyu_adapter::path::adapter::config_dir()
-						.join({{ adapter_name }})
-						.join({{ config_file_name }}),
+						.join(env!("CARGO_PKG_NAME"))
+						.join(#config_file_name),
 					value: ::puniyu_adapter::__private::toml::from_str(
-						&::puniyu_adapter::__private::toml::to_string(self).expect({{ serialize_error }}),
-					).expect("Failed to parse TOML string to Value"),
+						&::puniyu_adapter::__private::toml::to_string(self).expect(#serialize_error),
+					)
+					.expect("Failed to parse TOML string to Value"),
 				}
 			}
 		}
 
 		::puniyu_adapter::__private::inventory::submit! {
 			crate::ConfigRegistry {
-				adapter_name: {{ adapter_name }},
+				adapter_name: env!("CARGO_PKG_NAME"),
 				builder: || -> ::std::sync::Arc<dyn ::puniyu_adapter::__private::Config> {
-					::std::sync::Arc::new( {{ struct_name}}::default())
+					::std::sync::Arc::new(#struct_name::default())
 				}
 			}
 		}
 	}
-	.into_token_stream()
 }

--- a/crates/puniyu_macros/src/adapter/hook.rs
+++ b/crates/puniyu_macros/src/adapter/hook.rs
@@ -1,10 +1,11 @@
 use crate::{
 	HookArgs,
-	common::{validate_async, validate_hook_args, validate_return_type},
+	common::{default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async, validate_hook_args, validate_return_type},
 };
-use zyn::{ToTokens, syn::spanned::Spanned, zyn};
+use quote::quote;
+use syn::{ItemFn, spanned::Spanned};
 
-pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
+pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
 	if let Err(err) = validate_async(&fn_sig) {
 		return err.to_compile_error();
@@ -17,113 +18,29 @@ pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
 	}
 
 	let fn_name = &fn_sig.ident;
-	let struct_name = zyn! {{ fn_name | fmt: "{}Hook" | pascal }};
-	let adapter_name = zyn! { env!("CARGO_PKG_NAME") };
-	let hook_name = match &cfg.name {
-		Some(name) => zyn! { {{ name | str }} },
-		_ => zyn! { {{ fn_name | lower | str }} },
+	let struct_name = function_struct_ident(fn_name, "Hook");
+	let hook_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
+	let hook_type = match hook_type_tokens("adapter", cfg.hook_type.as_deref(), fn_sig.span()) {
+		Ok(tokens) => tokens,
+		Err(err) => return err.to_compile_error(),
 	};
-	let hook_type = match &cfg.hook_type {
-		Some(type_str) => {
-			let parts: Vec<&str> = type_str.split('.').collect();
-			match parts.as_slice() {
-				["event"] => zyn! {
-					::puniyu_adapter::hook::HookType::Event(
-						::puniyu_adapter::hook::HookEventType::default()
-					)
-				},
-				["event", "message"] => zyn! {
-					::puniyu_adapter::hook::HookType::Event(
-						::puniyu_adapter::hook::HookEventType::Message
-					)
-				},
-				["event", "extension"] => zyn! {
-					::puniyu_adapter::hook::HookType::Event(
-						::puniyu_adapter::hook::HookEventType::Extension
-					)
-				},
-				["event", "all"] => zyn! {
-					::puniyu_adapter::hook::HookType::Event(
-						::puniyu_adapter::hook::HookEventType::All
-					)
-				},
-				["status"] => zyn! {
-					::puniyu_adapter::hook::HookType::Status(
-						::puniyu_adapter::hook::StatusType::default()
-					)
-				},
-				["status", "start"] => zyn! {
-					::puniyu_adapter::hook::HookType::Status(
-						::puniyu_adapter::hook::StatusType::Start
-					)
-				},
-				["status", "stop"] => zyn! {
-					::puniyu_adapter::hook::HookType::Status(
-						::puniyu_adapter::hook::StatusType::Stop
-					)
-				},
-				["event", subtype] => {
-					let err_msg = format!(
-						"Invalid event subtype '{}'. Valid event subtypes are: 'message', 'extension', 'all'. \
-						Examples: 'event.message', 'event.all'",
-						subtype
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				["status", subtype] => {
-					let err_msg = format!(
-						"Invalid status subtype '{}'. Valid status subtypes are: 'start', 'stop'. \
-						Examples: 'status.start', 'status.stop'",
-						subtype
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				[category, _] => {
-					let err_msg = format!(
-						"Invalid hook category '{}'. Valid categories are: 'event', 'status'. \
-						Examples: 'event.message', 'status.start'",
-						category
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				[category] => {
-					let err_msg = format!(
-						"Invalid hook category '{}'. Valid categories are: 'event', 'status'. \
-						Examples: 'event', 'event.message', 'status.start'",
-						category
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				_ => {
-					let err_msg = format!(
-						"Invalid hook type format '{}'. Expected format: 'category' or 'category.subtype'. \
-						Examples: 'event', 'event.message', 'status.start'",
-						type_str
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-			}
-		}
-		None => zyn! { ::puniyu_adapter::hook::HookType::default() },
-	};
-	let hook_priority = match &cfg.priority {
-		Some(priority) => zyn! { {{ priority }} },
-		_ => zyn! { 500 },
-	};
+	let hook_priority = cfg.priority.unwrap_or(500);
 
-	zyn! {
-		{{ item }}
+	quote! {
+		#item
 
-		struct {{ struct_name }};
+		struct #struct_name;
 
 		#[::puniyu_adapter::__private::async_trait]
-		impl ::puniyu_adapter::__private::Hook for {{ struct_name }} {
+		impl ::puniyu_adapter::__private::Hook for #struct_name {
 			fn name(&self) -> &'static str {
 				#hook_name
 			}
 
-			fn r#type(&self) -> ::puniyu_adapter::hook::HookType {
-				#hook_type
+			fn r#type(&self) -> &::puniyu_adapter::hook::HookType {
+				static HOOK_TYPE: ::std::sync::LazyLock<::puniyu_adapter::hook::HookType> =
+					::std::sync::LazyLock::new(|| #hook_type);
+				&HOOK_TYPE
 			}
 
 			fn priority(&self) -> u32 {
@@ -133,20 +50,19 @@ pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
 			#[inline]
 			async fn execute(
 				&self,
-				event: Option<&Event>,
+				_event: Option<&::puniyu_adapter::context::EventContext>,
 			) -> ::puniyu_adapter::Result {
-				{{ fn_name }}(event).await
+				#fn_name(self.r#type()).await
 			}
 		}
 
 		::puniyu_adapter::__private::inventory::submit! {
 			crate::HookRegistry {
-				adapter_name: {{ adapter_name }},
+				adapter_name: env!("CARGO_PKG_NAME"),
 				builder: || -> ::std::sync::Arc<dyn ::puniyu_adapter::__private::Hook> {
-					::std::sync::Arc::new({{ struct_name }} {})
+					::std::sync::Arc::new(#struct_name {})
 				}
 			}
 		}
 	}
-	.to_token_stream()
 }

--- a/crates/puniyu_macros/src/adapter/hook.rs
+++ b/crates/puniyu_macros/src/adapter/hook.rs
@@ -1,9 +1,12 @@
 use crate::{
 	HookArgs,
-	common::{default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async, validate_hook_args, validate_return_type},
+	common::{
+		default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async,
+		validate_hook_args, validate_return_type,
+	},
 };
 use quote::quote;
-use syn::{ItemFn, spanned::Spanned};
+use syn::{ItemFn, LitStr, spanned::Spanned};
 
 pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
@@ -20,7 +23,9 @@ pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_name = &fn_sig.ident;
 	let struct_name = function_struct_ident(fn_name, "Hook");
 	let hook_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
-	let hook_type = match hook_type_tokens("adapter", cfg.hook_type.as_deref(), fn_sig.span()) {
+	let hook_type_value = cfg.hook_type.as_ref().map(LitStr::value);
+	let hook_type_span = cfg.hook_type.as_ref().map_or_else(|| fn_sig.span(), LitStr::span);
+	let hook_type = match hook_type_tokens("adapter", hook_type_value.as_deref(), hook_type_span) {
 		Ok(tokens) => tokens,
 		Err(err) => return err.to_compile_error(),
 	};

--- a/crates/puniyu_macros/src/common.rs
+++ b/crates/puniyu_macros/src/common.rs
@@ -31,11 +31,18 @@ pub(crate) fn validate_zero_args(fn_sig: &Signature) -> Result<()> {
 	Ok(())
 }
 
-pub(crate) fn validate_single_ref_arg<'a>(fn_sig: &'a Signature, receiver_err: &str) -> Result<&'a Type> {
+pub(crate) fn validate_single_ref_arg<'a>(
+	fn_sig: &'a Signature,
+	receiver_err: &str,
+) -> Result<&'a Type> {
 	if fn_sig.inputs.len() != 1 {
 		return Err(syn::Error::new(
 			fn_sig.span(),
-			format!("function `{}` must have exactly 1 parameter, found {}", fn_sig.ident, fn_sig.inputs.len()),
+			format!(
+				"function `{}` must have exactly 1 parameter, found {}",
+				fn_sig.ident,
+				fn_sig.inputs.len()
+			),
 		));
 	}
 
@@ -47,10 +54,9 @@ pub(crate) fn validate_single_ref_arg<'a>(fn_sig: &'a Signature, receiver_err: &
 
 	match pat_type.ty.as_ref() {
 		Type::Reference(type_ref) => Ok(type_ref.elem.as_ref()),
-		_ => Err(syn::Error::new(
-			pat_type.ty.span(),
-			"function parameter must be a reference type",
-		)),
+		_ => {
+			Err(syn::Error::new(pat_type.ty.span(), "function parameter must be a reference type"))
+		}
 	}
 }
 
@@ -65,18 +71,11 @@ pub(crate) fn validate_return_type(fn_sig: &Signature, expected: &str) -> Result
 		return err(ty.span());
 	};
 	let actual = normalize_path_string(&type_path.path);
-	if actual == expected || actual == format!("::{expected}") {
-		Ok(())
-	} else {
-		err(ty.span())
-	}
+	if actual == expected || actual == format!("::{expected}") { Ok(()) } else { err(ty.span()) }
 }
 
 pub(crate) fn function_struct_ident(fn_name: &Ident, suffix: &str) -> Ident {
-	Ident::new(
-		&format!("{}{}", fn_name.to_string().to_case(Case::Pascal), suffix),
-		fn_name.span(),
-	)
+	Ident::new(&format!("{}{}", fn_name.to_string().to_case(Case::Pascal), suffix), fn_name.span())
 }
 
 pub(crate) fn default_name_from_ident(ident: &Ident) -> String {
@@ -89,7 +88,11 @@ pub(crate) fn config_name(explicit_name: Option<&str>, ident: &Ident) -> String 
 		.unwrap_or_else(|| default_name_from_ident(ident))
 }
 
-pub(crate) fn hook_type_tokens(root: &str, hook_type: Option<&str>, span: proc_macro2::Span) -> Result<TokenStream> {
+pub(crate) fn hook_type_tokens(
+	root: &str,
+	hook_type: Option<&str>,
+	span: proc_macro2::Span,
+) -> Result<TokenStream> {
 	let root = match root {
 		"plugin" => quote!(::puniyu_plugin::hook),
 		"adapter" => quote!(::puniyu_adapter::hook),
@@ -104,30 +107,42 @@ pub(crate) fn hook_type_tokens(root: &str, hook_type: Option<&str>, span: proc_m
 	match parts.as_slice() {
 		["event"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::default()))),
 		["event", "message"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::Message))),
-		["event", "extension"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::Extension))),
+		["event", "extension"] => {
+			Ok(quote!(#root::HookType::Event(#root::HookEventType::Extension)))
+		}
 		["event", "all"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::All))),
 		["status"] => Ok(quote!(#root::HookType::Status(#root::StatusType::default()))),
 		["status", "start"] => Ok(quote!(#root::HookType::Status(#root::StatusType::Start))),
 		["status", "stop"] => Ok(quote!(#root::HookType::Status(#root::StatusType::Stop))),
 		["event", subtype] => Err(syn::Error::new(
 			span,
-			format!("Invalid event subtype '{subtype}'. Valid event subtypes are: 'message', 'extension', 'all'. Examples: 'event.message', 'event.all'"),
+			format!(
+				"Invalid event subtype '{subtype}'. Valid event subtypes are: 'message', 'extension', 'all'. Examples: 'event.message', 'event.all'"
+			),
 		)),
 		["status", subtype] => Err(syn::Error::new(
 			span,
-			format!("Invalid status subtype '{subtype}'. Valid status subtypes are: 'start', 'stop'. Examples: 'status.start', 'status.stop'"),
+			format!(
+				"Invalid status subtype '{subtype}'. Valid status subtypes are: 'start', 'stop'. Examples: 'status.start', 'status.stop'"
+			),
 		)),
 		[category, _] => Err(syn::Error::new(
 			span,
-			format!("Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event.message', 'status.start'"),
+			format!(
+				"Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event.message', 'status.start'"
+			),
 		)),
 		[category] => Err(syn::Error::new(
 			span,
-			format!("Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event', 'event.message', 'status.start'"),
+			format!(
+				"Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event', 'event.message', 'status.start'"
+			),
 		)),
 		_ => Err(syn::Error::new(
 			span,
-			format!("Invalid hook type format '{hook_type}'. Expected format: 'category' or 'category.subtype'. Examples: 'event', 'event.message', 'status.start'"),
+			format!(
+				"Invalid hook type format '{hook_type}'. Expected format: 'category' or 'category.subtype'. Examples: 'event', 'event.message', 'status.start'"
+			),
 		)),
 	}
 }
@@ -136,11 +151,14 @@ pub(crate) fn path_matches(ty: &Type, expected_segments: &[&str]) -> bool {
 	let Type::Path(type_path) = ty else {
 		return false;
 	};
-	let actual: Vec<String> = type_path.path.segments.iter().map(|segment| segment.ident.to_string()).collect();
+	let actual: Vec<String> =
+		type_path.path.segments.iter().map(|segment| segment.ident.to_string()).collect();
 	if actual == expected_segments.iter().map(|segment| segment.to_string()).collect::<Vec<_>>() {
 		return true;
 	}
-	if actual.last().is_some_and(|segment| segment == expected_segments.last().copied().unwrap_or_default())
+	if actual
+		.last()
+		.is_some_and(|segment| segment == expected_segments.last().copied().unwrap_or_default())
 		&& expected_segments.len() == 1
 	{
 		return true;

--- a/crates/puniyu_macros/src/common.rs
+++ b/crates/puniyu_macros/src/common.rs
@@ -1,78 +1,153 @@
-use zyn::{
-	ToTokens,
-	syn::{self, spanned::Spanned},
-};
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+use syn::{FnArg, Ident, Path, Result, Signature, Type, spanned::Spanned};
 
-pub(crate) fn validate_async(fn_sig: &syn::Signature) -> syn::Result<()> {
+pub(crate) fn validate_async(fn_sig: &Signature) -> Result<()> {
 	if fn_sig.asyncness.is_none() {
 		return Err(syn::Error::new(fn_sig.span(), "function must be async"));
 	}
 	Ok(())
 }
 
-pub(crate) fn validate_hook_args(fn_sig: &syn::Signature) -> syn::Result<()> {
-	let fn_name = &fn_sig.ident;
-	let inputs = &fn_sig.inputs;
-	if inputs.len() != 1 {
+pub(crate) fn validate_hook_args(fn_sig: &Signature) -> Result<()> {
+	let arg_type = validate_single_ref_arg(fn_sig, "hook function parameter must not be `self`")?;
+	if !path_matches(arg_type, &["HookType"])
+		&& !path_matches(arg_type, &["puniyu_plugin", "hook", "HookType"])
+		&& !path_matches(arg_type, &["puniyu_adapter", "hook", "HookType"])
+	{
 		return Err(syn::Error::new(
-			fn_sig.span(),
-			format!("function `{}` must have exactly 1 parameter, found {}", fn_name, inputs.len()),
-		));
-	}
-
-	let arg = inputs.first().unwrap();
-	let pat_type = match arg {
-		syn::FnArg::Typed(pat_type) => pat_type,
-		syn::FnArg::Receiver(_) => {
-			return Err(syn::Error::new(arg.span(), "hook function parameter must not be `self`"));
-		}
-	};
-
-	let inner_type = match pat_type.ty.as_ref() {
-		syn::Type::Reference(type_ref) => &type_ref.elem,
-		_ => {
-			return Err(syn::Error::new(
-				pat_type.ty.span(),
-				"hook function parameter must be a reference: `&puniyu_plugin::hook::HookType` or `&puniyu_adapter::hook::HookType`",
-			));
-		}
-	};
-
-	let is_valid = match inner_type.as_ref() {
-		syn::Type::Path(type_path) => {
-			let path_str = type_path.path.to_token_stream().to_string().replace(' ', "");
-			matches!(
-				path_str.as_str(),
-				"HookType"
-					| "puniyu_plugin::hook::HookType"
-					| "::puniyu_plugin::hook::HookType"
-					| "puniyu_adapter::hook::HookType"
-					| "::puniyu_adapter::hook::HookType"
-			)
-		}
-		_ => false,
-	};
-
-	if !is_valid {
-		return Err(syn::Error::new(
-			inner_type.span(),
+			arg_type.span(),
 			"hook function parameter type must be `puniyu_plugin::hook::HookType` or `puniyu_adapter::hook::HookType`",
 		));
 	}
-
 	Ok(())
 }
 
-pub(crate) fn validate_return_type(fn_sig: &syn::Signature, expected: &str) -> syn::Result<()> {
+pub(crate) fn validate_zero_args(fn_sig: &Signature) -> Result<()> {
+	if !fn_sig.inputs.is_empty() {
+		return Err(syn::Error::new(fn_sig.span(), "function must not have parameters"));
+	}
+	Ok(())
+}
+
+pub(crate) fn validate_single_ref_arg<'a>(fn_sig: &'a Signature, receiver_err: &str) -> Result<&'a Type> {
+	if fn_sig.inputs.len() != 1 {
+		return Err(syn::Error::new(
+			fn_sig.span(),
+			format!("function `{}` must have exactly 1 parameter, found {}", fn_sig.ident, fn_sig.inputs.len()),
+		));
+	}
+
+	let arg = fn_sig.inputs.first().expect("checked len");
+	let pat_type = match arg {
+		FnArg::Typed(pat_type) => pat_type,
+		FnArg::Receiver(_) => return Err(syn::Error::new(arg.span(), receiver_err)),
+	};
+
+	match pat_type.ty.as_ref() {
+		Type::Reference(type_ref) => Ok(type_ref.elem.as_ref()),
+		_ => Err(syn::Error::new(
+			pat_type.ty.span(),
+			"function parameter must be a reference type",
+		)),
+	}
+}
+
+pub(crate) fn validate_return_type(fn_sig: &Signature, expected: &str) -> Result<()> {
 	let expected = expected.replace(' ', "");
 	let err = |span| Err(syn::Error::new(span, format!("function must return `{expected}`")));
 
 	let syn::ReturnType::Type(_, ty) = &fn_sig.output else {
 		return err(fn_sig.span());
 	};
-	let syn::Type::Path(type_path) = ty.as_ref() else {
+	let Type::Path(type_path) = ty.as_ref() else {
 		return err(ty.span());
 	};
-	let actual = type_path.path.to_token_stream().to_string().replace(' ', "");
-	if actual == expected || actual == format!("::{expected}") { Ok(()) } else { err(ty.span()) }
+	let actual = normalize_path_string(&type_path.path);
+	if actual == expected || actual == format!("::{expected}") {
+		Ok(())
+	} else {
+		err(ty.span())
+	}
+}
+
+pub(crate) fn function_struct_ident(fn_name: &Ident, suffix: &str) -> Ident {
+	Ident::new(
+		&format!("{}{}", fn_name.to_string().to_case(Case::Pascal), suffix),
+		fn_name.span(),
+	)
+}
+
+pub(crate) fn default_name_from_ident(ident: &Ident) -> String {
+	ident.to_string().to_case(Case::Snake)
+}
+
+pub(crate) fn config_name(explicit_name: Option<&str>, ident: &Ident) -> String {
+	explicit_name
+		.map(|name| name.to_case(Case::Snake))
+		.unwrap_or_else(|| default_name_from_ident(ident))
+}
+
+pub(crate) fn hook_type_tokens(root: &str, hook_type: Option<&str>, span: proc_macro2::Span) -> Result<TokenStream> {
+	let root = match root {
+		"plugin" => quote!(::puniyu_plugin::hook),
+		"adapter" => quote!(::puniyu_adapter::hook),
+		_ => return Err(syn::Error::new(span, "invalid hook root")),
+	};
+
+	let Some(hook_type) = hook_type else {
+		return Ok(quote!(#root::HookType::default()));
+	};
+
+	let parts: Vec<&str> = hook_type.split('.').collect();
+	match parts.as_slice() {
+		["event"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::default()))),
+		["event", "message"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::Message))),
+		["event", "extension"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::Extension))),
+		["event", "all"] => Ok(quote!(#root::HookType::Event(#root::HookEventType::All))),
+		["status"] => Ok(quote!(#root::HookType::Status(#root::StatusType::default()))),
+		["status", "start"] => Ok(quote!(#root::HookType::Status(#root::StatusType::Start))),
+		["status", "stop"] => Ok(quote!(#root::HookType::Status(#root::StatusType::Stop))),
+		["event", subtype] => Err(syn::Error::new(
+			span,
+			format!("Invalid event subtype '{subtype}'. Valid event subtypes are: 'message', 'extension', 'all'. Examples: 'event.message', 'event.all'"),
+		)),
+		["status", subtype] => Err(syn::Error::new(
+			span,
+			format!("Invalid status subtype '{subtype}'. Valid status subtypes are: 'start', 'stop'. Examples: 'status.start', 'status.stop'"),
+		)),
+		[category, _] => Err(syn::Error::new(
+			span,
+			format!("Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event.message', 'status.start'"),
+		)),
+		[category] => Err(syn::Error::new(
+			span,
+			format!("Invalid hook category '{category}'. Valid categories are: 'event', 'status'. Examples: 'event', 'event.message', 'status.start'"),
+		)),
+		_ => Err(syn::Error::new(
+			span,
+			format!("Invalid hook type format '{hook_type}'. Expected format: 'category' or 'category.subtype'. Examples: 'event', 'event.message', 'status.start'"),
+		)),
+	}
+}
+
+pub(crate) fn path_matches(ty: &Type, expected_segments: &[&str]) -> bool {
+	let Type::Path(type_path) = ty else {
+		return false;
+	};
+	let actual: Vec<String> = type_path.path.segments.iter().map(|segment| segment.ident.to_string()).collect();
+	if actual == expected_segments.iter().map(|segment| segment.to_string()).collect::<Vec<_>>() {
+		return true;
+	}
+	if actual.last().is_some_and(|segment| segment == expected_segments.last().copied().unwrap_or_default())
+		&& expected_segments.len() == 1
+	{
+		return true;
+	}
+	false
+}
+
+pub(crate) fn normalize_path_string(path: &Path) -> String {
+	path.to_token_stream().to_string().replace(' ', "")
 }

--- a/crates/puniyu_macros/src/lib.rs
+++ b/crates/puniyu_macros/src/lib.rs
@@ -237,7 +237,7 @@ pub fn plugin_config(
 ///
 /// # 参数
 ///
-/// - `name = "..."`：必填，命令名。
+/// - `name = "..."`：可选，命令名；默认从函数名推导并转换为 snake_case。
 /// - `priority = 100`：可选，优先级；默认 `500`。
 /// - `desc = "..."`：可选，命令描述。
 /// - `alias = ["a", "b"]`：可选，命令别名列表。
@@ -256,7 +256,6 @@ pub fn plugin_config(
 /// # 常见错误
 ///
 /// - 函数不是 `async fn`。
-/// - 缺少 `name`。
 /// - `permission` 值不合法。
 /// - 参数或返回类型不匹配。
 ///
@@ -267,7 +266,7 @@ pub fn plugin_config(
 /// use puniyu_macros::{arg, command};
 /// use puniyu_plugin::command::CommandAction;
 ///
-/// #[command(name = "echo", desc = "echo", permission = "all")]
+/// #[command(desc = "echo", permission = "all")]
 /// #[arg(name = "message", desc = "消息")]
 /// async fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
 ///     CommandAction::done()
@@ -300,7 +299,7 @@ pub fn command(
 /// - `desc = "..."`：可选，参数描述。
 ///
 /// `arg_type` 支持：`string`、`integer`、`int`、`float`、`boolean`、`bool`。
-/// `mode` 支持：`positional`、`named`、`optional`。
+/// `mode` 支持：`positional`、`named`。
 ///
 /// # 约束
 ///

--- a/crates/puniyu_macros/src/lib.rs
+++ b/crates/puniyu_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! # puniyu_macros
 //!
-//! `puniyu_macros` 提供 puniyu 生态中的过程宏，用于声明插件、命令、任务、配置和适配器入口。
+//! `puniyu_macros` 提供 puniyu 生态中的过程宏，用于声明插件、适配器、命令、任务、Hook 和配置，减少 trait 实现与 `inventory` 注册样板代码。
 //!
 //! ## 插件侧宏
 //!
@@ -17,10 +17,23 @@
 //! - [`adapter_config`]：声明适配器配置结构体
 //! - [`adapter_hook`]：声明适配器钩子函数
 //!
+//! ## 编译期校验
+//!
+//! 大多数函数类宏会在编译期校验以下内容：
+//!
+//! - 被标注项是否为 `async fn`
+//! - 函数参数和返回类型是否满足约束
+//! - 属性参数是否使用合法的 key-value 形式
+//! - `cron`、`hook_type`、`permission` 等枚举值或格式是否有效
+//!
+//! ## 生成行为
+//!
+//! 这些宏会生成对应 trait 的实现，并通过 `inventory` 注册元数据，供运行时收集插件、适配器、命令、任务、Hook 和配置。
+//!
 //! ## 示例
 //!
 //! ```rust, ignore
-//! use puniyu_plugin::prelude::*;
+//! use puniyu_macros::plugin;
 //!
 //! #[plugin]
 //! async fn __main() {}
@@ -38,6 +51,23 @@ fn parse_attr<T: syn::parse::Parse>(
 	syn::parse(tokens).map_err(|err| err.to_compile_error().into())
 }
 
+fn arg_marker(args: proc_macro::TokenStream) -> proc_macro2::TokenStream {
+	let args: proc_macro2::TokenStream = args.into();
+	quote::quote!(#[__puniyu_arg(#args)])
+}
+
+/// 声明适配器配置结构体。
+///
+/// # 参数
+///
+/// - `name = "..."`：可选，配置名；默认从结构体名推导并转换为 snake_case。
+///
+/// # 约束
+///
+/// - 只能标注在结构体上。
+/// - 被标注结构体需要实现 `Default`。
+/// - 被标注结构体需要能序列化为 TOML。
+///
 #[proc_macro_attribute]
 pub fn adapter_config(
 	args: proc_macro::TokenStream,
@@ -54,6 +84,22 @@ pub fn adapter_config(
 	adapter::config(item, cfg).into()
 }
 
+/// 声明适配器 Hook 函数。
+///
+/// # 参数
+///
+/// - `name = "..."`：可选，Hook 名；默认从函数名推导。
+/// - `hook_type = "..."`：可选，也可写作 `type` 或 `r#type`；默认使用 `HookType::default()`。
+/// - `priority = 100`：可选，优先级；默认 `500`。
+///
+/// `hook_type` 支持：`event`、`event.message`、`event.extension`、`event.all`、`status`、`status.start`、`status.stop`。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 函数必须接收一个 `&HookType` 参数。
+/// - 函数必须返回 `puniyu_adapter::Result`。
+///
 #[proc_macro_attribute]
 pub fn adapter_hook(
 	args: proc_macro::TokenStream,
@@ -70,6 +116,30 @@ pub fn adapter_hook(
 	adapter::hook(item, cfg).into()
 }
 
+/// 声明适配器入口函数。
+///
+/// # 参数
+///
+/// - `runtime = path`：必填，返回 `Arc<dyn puniyu_adapter::runtime::AdapterRuntime>` 的函数或表达式。
+/// - `server = path`：可选，适配器服务函数。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 函数必须返回 `puniyu_adapter::Result`。
+/// - 空函数体不会生成 `init` 调用；非空函数体会作为适配器初始化逻辑调用。
+///
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_macros::adapter;
+///
+/// #[adapter(runtime = runtime)]
+/// async fn __main() -> puniyu_adapter::Result {
+///     Ok(())
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn adapter(
 	args: proc_macro::TokenStream,
@@ -86,6 +156,28 @@ pub fn adapter(
 	adapter::adapter(item, cfg).into()
 }
 
+/// 声明插件入口函数。
+///
+/// # 参数
+///
+/// - `desc = "..."`：可选，插件描述。
+/// - `prefix = "..."`：可选，命令前缀。
+/// - `server = path`：可选，插件服务函数。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 当函数体非空时，函数必须返回 `puniyu_plugin::Result`。
+/// - 空函数体不会生成 `init` 调用；非空函数体会作为插件初始化逻辑调用。
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_macros::plugin;
+///
+/// #[plugin]
+/// async fn __main() {}
+/// ```
 #[proc_macro_attribute]
 pub fn plugin(
 	args: proc_macro::TokenStream,
@@ -102,6 +194,29 @@ pub fn plugin(
 	plugin::plugin(item, cfg).into()
 }
 
+/// 声明插件配置结构体。
+///
+/// # 参数
+///
+/// - `name = "..."`：可选，配置名；默认从结构体名推导并转换为 snake_case。
+///
+/// # 约束
+///
+/// - 只能标注在结构体上。
+/// - 被标注结构体需要实现 `Default`。
+/// - 被标注结构体需要能序列化为 TOML。
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_macros::plugin_config;
+///
+/// #[derive(Default, serde::Serialize, serde::Deserialize)]
+/// #[plugin_config(name = "sample")]
+/// struct SampleConfig {
+///     value: String,
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn plugin_config(
 	args: proc_macro::TokenStream,
@@ -118,6 +233,46 @@ pub fn plugin_config(
 	plugin::config(item, cfg).into()
 }
 
+/// 声明插件命令处理函数。
+///
+/// # 参数
+///
+/// - `name = "..."`：必填，命令名。
+/// - `priority = 100`：可选，优先级；默认 `500`。
+/// - `desc = "..."`：可选，命令描述。
+/// - `alias = ["a", "b"]`：可选，命令别名列表。
+/// - `permission = "all"`：可选，命令权限；默认 `all`。
+///
+/// `permission` 支持：`all`、`master`、`owner`、`admin`。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 函数必须接收一个 `&MessageContext` 参数。
+/// - 函数必须返回 `puniyu_plugin::Result<CommandAction>`。
+/// - 可配合多个 [`arg`] 属性声明命令参数。
+///
+///
+/// # 常见错误
+///
+/// - 函数不是 `async fn`。
+/// - 缺少 `name`。
+/// - `permission` 值不合法。
+/// - 参数或返回类型不匹配。
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_context::MessageContext;
+/// use puniyu_macros::{arg, command};
+/// use puniyu_plugin::command::CommandAction;
+///
+/// #[command(name = "echo", desc = "echo", permission = "all")]
+/// #[arg(name = "message", desc = "消息")]
+/// async fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+///     CommandAction::done()
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn command(
 	args: proc_macro::TokenStream,
@@ -134,14 +289,61 @@ pub fn command(
 	plugin::command(item, cfg).into()
 }
 
+/// 为 [`command`] 声明命令参数。
+///
+/// # 参数
+///
+/// - `name = "..."`：必填，参数名。
+/// - `arg_type = "string"`：可选，也可写作 `type` 或 `r#type`；默认 `string`。
+/// - `mode = "positional"`：可选，默认 `positional`。
+/// - `required = true`：可选，是否必填；默认 `false`。
+/// - `desc = "..."`：可选，参数描述。
+///
+/// `arg_type` 支持：`string`、`integer`、`int`、`float`、`boolean`、`bool`。
+/// `mode` 支持：`positional`、`named`、`optional`。
+///
+/// # 约束
+///
+/// - 该属性应与 [`command`] 一起使用。
+/// - 该宏会先校验自身参数格式，再写入内部参数标记供 [`command`] 收集处理。
+///
 #[proc_macro_attribute]
 pub fn arg(
-	_args: proc_macro::TokenStream,
+	args: proc_macro::TokenStream,
 	item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-	item
+	if let Err(err) = ArgType::parse_tokens(args.clone().into()) {
+		return err.to_compile_error().into();
+	}
+	let marker = arg_marker(args);
+	let item: proc_macro2::TokenStream = item.into();
+	quote::quote!(#marker #item).into()
 }
 
+/// 声明插件定时任务函数。
+///
+/// # 参数
+///
+/// - `cron = "..."`：必填，cron 表达式。
+/// - `name = "..."`：可选，任务名；默认从函数名推导。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 函数不能有参数。
+/// - 函数必须返回 `puniyu_plugin::Result`。
+/// - `cron` 必须能被 `croner::Cron` 解析。
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_macros::task;
+///
+/// #[task(cron = "0 * * * * *", name = "health_check")]
+/// async fn health_check() -> puniyu_plugin::Result {
+///     Ok(())
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn task(
 	args: proc_macro::TokenStream,
@@ -158,6 +360,38 @@ pub fn task(
 	plugin::task(item, cfg).into()
 }
 
+/// 声明插件 Hook 函数。
+///
+/// # 参数
+///
+/// - `name = "..."`：可选，Hook 名；默认从函数名推导。
+/// - `hook_type = "..."`：可选，也可写作 `type` 或 `r#type`；默认使用 `HookType::default()`。
+/// - `priority = 100`：可选，优先级；默认 `500`。
+///
+/// `hook_type` 支持：`event`、`event.message`、`event.extension`、`event.all`、`status`、`status.start`、`status.stop`。
+///
+/// # 约束
+///
+/// - 被标注项必须是 `async fn`。
+/// - 函数必须接收一个 `&HookType` 参数。
+/// - 函数必须返回 `puniyu_plugin::Result`。
+///
+/// # 生成行为
+///
+/// - 生成 Hook 包装结构体并实现 `puniyu_plugin::__private::Hook`。
+/// - 通过插件侧 `HookRegistry` 注册 Hook 构造器。
+///
+/// # 示例
+///
+/// ```rust, ignore
+/// use puniyu_macros::plugin_hook;
+/// use puniyu_plugin::hook::HookType;
+///
+/// #[plugin_hook(name = "on_message", hook_type = "event.message", priority = 100)]
+/// async fn on_message(_event: &HookType) -> puniyu_plugin::Result {
+///     Ok(())
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn plugin_hook(
 	args: proc_macro::TokenStream,

--- a/crates/puniyu_macros/src/lib.rs
+++ b/crates/puniyu_macros/src/lib.rs
@@ -32,280 +32,115 @@ mod plugin;
 mod types;
 pub(crate) use types::*;
 
-use zyn::{ToTokens, syn::spanned::Spanned};
-
-/// 声明适配器配置结构体。
-///
-/// 该宏会为结构体生成适配器配置注册逻辑，并使用结构体的默认值作为初始配置。
-/// 默认配置名取结构体名的 snake_case，也可以通过 `name` 参数覆盖。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::adapter_config;
-/// use serde::{Deserialize, Serialize};
-///
-/// #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-/// #[adapter_config(name = "console")]
-/// pub struct ConsoleConfig {
-///     pub enabled: bool,
-///     pub prompt: String,
-/// }
-/// ```
-#[zyn::attribute]
-pub fn adapter_config(
-	#[zyn(input)] item: zyn::syn::ItemStruct,
-	args: zyn::Args,
-) -> zyn::TokenStream {
-	let cfg = match ConfigArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
-	};
-	adapter::config(item, cfg)
+fn parse_attr<T: syn::parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T, proc_macro::TokenStream> {
+	syn::parse(tokens).map_err(|err| err.to_compile_error().into())
 }
 
-/// 声明适配器钩子函数。
-///
-/// 要求函数为 `async`，接收一个引用参数，对应适配器侧 `HookType`，并返回
-/// `puniyu_adapter::Result`。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_adapter::hook::HookType;
-/// use puniyu_macros::adapter_hook;
-///
-/// #[adapter_hook(name = "on_start", hook_type = "status.start", priority = 100)]
-/// async fn on_start(event: &HookType) -> puniyu_adapter::Result {
-///     let _ = event;
-///     Ok(())
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn adapter_hook(
-	#[zyn(input)] item: zyn::syn::ItemFn,
-	args: zyn::Args,
-) -> proc_macro::TokenStream {
-	let cfg = match HookArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn adapter_config(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemStruct>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	adapter::hook(item, cfg)
+	let cfg = match ConfigArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	adapter::config(item, cfg).into()
 }
 
-/// 声明适配器入口函数。
-///
-/// 参数中需要提供：
-/// - `info`：返回 `AdapterInfo` 的函数
-/// - `runtime`：返回适配器运行时的函数
-///
-/// 要求函数为 `async`。当函数体非空时，返回类型必须为 `puniyu_adapter::Result`；
-/// 当函数体为空时，可以省略返回值类型。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_adapter::types::*;
-/// use puniyu_macros::adapter;
-///
-/// #[adapter(runtime = runtime::runtime)]
-/// async fn main() -> puniyu_adapter::Result {
-///     Ok(())
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn adapter(#[zyn(input)] item: zyn::syn::ItemFn, args: zyn::Args) -> proc_macro::TokenStream {
-	let cfg = match AdapterArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn adapter_hook(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	adapter::adapter(item, cfg)
+	let cfg = match HookArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	adapter::hook(item, cfg).into()
 }
 
-/// 声明插件入口函数。
-///
-/// 可选参数：
-/// - `desc`：插件描述
-/// - `prefix`：插件命令前缀
-///
-/// 要求函数为 `async`。当函数体非空时，返回类型必须为 `puniyu_plugin::Result`；
-/// 当函数体为空时，可以省略返回值类型。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::plugin;
-/// use puniyu_plugin::prelude::*;
-///
-/// #[plugin(desc = "基础功能插件", prefix = "basic")]
-/// async fn __main() -> puniyu_plugin::Result {
-///     Ok(())
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn plugin(#[zyn(input)] item: zyn::syn::ItemFn, args: zyn::Args) -> proc_macro::TokenStream {
-	let cfg = match PluginArg::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn adapter(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	plugin::plugin(item, cfg)
+	let cfg = match AdapterArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	adapter::adapter(item, cfg).into()
 }
 
-/// 声明插件配置结构体。
-///
-/// 该宏会为结构体生成插件配置注册逻辑，并使用结构体的默认值作为初始配置。
-/// 默认配置名取结构体名的 snake_case，也可以通过 `name` 参数覆盖。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::plugin_config;
-/// use serde::{Deserialize, Serialize};
-///
-/// #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-/// #[plugin_config(name = "basic")]
-/// pub struct BasicConfig {
-///     pub enabled: bool,
-///     pub prefix: String,
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn plugin_config(
-	#[zyn(input)] item: zyn::syn::ItemStruct,
-	args: zyn::Args,
-) -> proc_macro::TokenStream {
-	let cfg = match ConfigArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn plugin(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	plugin::config(item, cfg)
+	let cfg = match PluginArg::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	plugin::plugin(item, cfg).into()
 }
 
-/// 声明命令处理函数。
-///
-/// 常用参数：
-/// - `name`：命令名称，必填
-/// - `desc`：命令描述，可选
-/// - `priority`：优先级，可选
-/// - `alias`：别名列表，可选
-/// - `permission`：权限，可选，支持 `"all"` 和 `"admin"`
-///
-/// 要求：
-/// - 函数必须是 `async`
-/// - 必须且只能接收一个参数：`&MessageContext<'_>`
-/// - 返回类型必须为 `puniyu_plugin::Result<CommandAction>`
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::{arg, command};
-/// use puniyu_plugin::prelude::*;
-///
-/// #[command(name = "echo", desc = "回显文本", alias = ["say"], priority = 100)]
-/// #[arg(name = "message", desc = "消息内容", required = true)]
-/// #[arg(name = "times", r#type = "integer", mode = "optional", desc = "重复次数")]
-/// async fn echo(ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
-///     Ok(CommandAction::Done)
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn command(#[zyn(input)] item: zyn::syn::ItemFn, cfg: zyn::Args) -> proc_macro::TokenStream {
-	let cfg = match CommandArgs::from_args(&cfg) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn plugin_config(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemStruct>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	plugin::command(item, cfg)
+	let cfg = match ConfigArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	plugin::config(item, cfg).into()
 }
 
-/// 为命令补充参数描述。
-///
-/// 该宏通常与 [`command`] 一起使用，常用参数包括：
-/// - `name`：参数名
-/// - `desc`：参数说明
-/// - `type`：参数类型，支持 `string`、`integer`、`boolean`
-/// - `mode`：参数模式，支持 `positional`、`optional`
-/// - `required`：是否必填
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::{arg, command};
-/// use puniyu_plugin::prelude::*;
-///
-/// #[command(name = "echo")]
-/// #[arg(name = "message", desc = "消息内容", required = true)]
-/// #[arg(name = "times", r#type = "integer", mode = "optional", desc = "重复次数")]
-/// #[arg(name = "silent", r#type = "boolean", mode = "optional", desc = "是否静默执行")]
-/// async fn echo(ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
-///     Ok(CommandAction::Done)
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn arg(#[zyn(input)] item: zyn::syn::ItemFn) -> proc_macro::TokenStream {
-	item.to_token_stream()
+#[proc_macro_attribute]
+pub fn command(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
+	};
+	let cfg = match CommandArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	plugin::command(item, cfg).into()
 }
 
-/// 声明定时任务函数。
-///
-/// 常用参数：
-/// - `cron`：cron 表达式，必填
-/// - `name`：任务名，可选
-///
-/// 要求：
-/// - 函数必须是 `async`
-/// - 函数不接收参数
-/// - 返回类型必须为 `puniyu_plugin::Result`
-/// - `cron` 会在编译时校验
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::task;
-/// use puniyu_plugin::prelude::*;
-///
-/// #[task(cron = "*/5 * * * *", name = "health_check")]
-/// async fn health_check() -> puniyu_plugin::Result {
-///     Ok(())
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn task(#[zyn(input)] item: zyn::syn::ItemFn, args: zyn::Args) -> proc_macro::TokenStream {
-	let cfg = match TaskArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
-	};
-	plugin::task(item, cfg)
+#[proc_macro_attribute]
+pub fn arg(_args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	item
 }
 
-/// 声明插件钩子函数。
-///
-/// 常用参数：
-/// - `name`：钩子名称，可选
-/// - `hook_type`：钩子类型，可选，如 `"event.message"`、`"status.start"`
-/// - `priority`：优先级，可选
-///
-/// 要求函数为 `async`，接收一个引用参数，对应插件侧 `HookType`，并返回
-/// `puniyu_plugin::Result`。
-///
-/// # 示例
-///
-/// ```rust, ignore
-/// use puniyu_macros::plugin_hook;
-/// use puniyu_plugin::hook::HookType;
-///
-/// #[plugin_hook(name = "on_message", hook_type = "event.message", priority = 100)]
-/// async fn on_message(event: &HookType) -> puniyu_plugin::Result {
-///     Ok(())
-/// }
-/// ```
-#[zyn::attribute(debug(pretty))]
-pub fn plugin_hook(
-	#[zyn(input)] item: zyn::syn::ItemFn,
-	args: zyn::Args,
-) -> proc_macro::TokenStream {
-	let cfg = match HookArgs::from_args(&args) {
-		Ok(cfg) => cfg,
-		Err(err) => bail!("{err}"),
+#[proc_macro_attribute]
+pub fn task(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
 	};
-	plugin::hook(item, cfg)
+	let cfg = match TaskArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	plugin::task(item, cfg).into()
+}
+
+#[proc_macro_attribute]
+pub fn plugin_hook(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let item = match parse_attr::<syn::ItemFn>(item) {
+		Ok(item) => item,
+		Err(err) => return err,
+	};
+	let cfg = match HookArgs::parse_tokens(args.into()) {
+		Ok(cfg) => cfg,
+		Err(err) => return err.to_compile_error().into(),
+	};
+	plugin::hook(item, cfg).into()
 }

--- a/crates/puniyu_macros/src/lib.rs
+++ b/crates/puniyu_macros/src/lib.rs
@@ -32,12 +32,17 @@ mod plugin;
 mod types;
 pub(crate) use types::*;
 
-fn parse_attr<T: syn::parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T, proc_macro::TokenStream> {
+fn parse_attr<T: syn::parse::Parse>(
+	tokens: proc_macro::TokenStream,
+) -> Result<T, proc_macro::TokenStream> {
 	syn::parse(tokens).map_err(|err| err.to_compile_error().into())
 }
 
 #[proc_macro_attribute]
-pub fn adapter_config(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn adapter_config(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemStruct>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -50,7 +55,10 @@ pub fn adapter_config(args: proc_macro::TokenStream, item: proc_macro::TokenStre
 }
 
 #[proc_macro_attribute]
-pub fn adapter_hook(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn adapter_hook(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -63,7 +71,10 @@ pub fn adapter_hook(args: proc_macro::TokenStream, item: proc_macro::TokenStream
 }
 
 #[proc_macro_attribute]
-pub fn adapter(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn adapter(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -76,7 +87,10 @@ pub fn adapter(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> 
 }
 
 #[proc_macro_attribute]
-pub fn plugin(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn plugin(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -89,7 +103,10 @@ pub fn plugin(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> p
 }
 
 #[proc_macro_attribute]
-pub fn plugin_config(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn plugin_config(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemStruct>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -102,7 +119,10 @@ pub fn plugin_config(args: proc_macro::TokenStream, item: proc_macro::TokenStrea
 }
 
 #[proc_macro_attribute]
-pub fn command(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn command(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -115,12 +135,18 @@ pub fn command(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> 
 }
 
 #[proc_macro_attribute]
-pub fn arg(_args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn arg(
+	_args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	item
 }
 
 #[proc_macro_attribute]
-pub fn task(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn task(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,
@@ -133,7 +159,10 @@ pub fn task(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> pro
 }
 
 #[proc_macro_attribute]
-pub fn plugin_hook(args: proc_macro::TokenStream, item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn plugin_hook(
+	args: proc_macro::TokenStream,
+	item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
 	let item = match parse_attr::<syn::ItemFn>(item) {
 		Ok(item) => item,
 		Err(err) => return err,

--- a/crates/puniyu_macros/src/plugin.rs
+++ b/crates/puniyu_macros/src/plugin.rs
@@ -10,9 +10,10 @@ use crate::{
 	common::{validate_async, validate_return_type},
 };
 pub use hook::hook;
-use zyn::{ToTokens, zyn};
+use quote::quote;
+use syn::ItemFn;
 
-pub fn plugin(item: zyn::syn::ItemFn, cfg: PluginArg) -> zyn::TokenStream {
+pub fn plugin(item: ItemFn, cfg: PluginArg) -> proc_macro2::TokenStream {
 	if let Err(err) = validate_async(&item.sig) {
 		return err.to_compile_error();
 	}
@@ -22,61 +23,60 @@ pub fn plugin(item: zyn::syn::ItemFn, cfg: PluginArg) -> zyn::TokenStream {
 		return err.to_compile_error();
 	}
 
-	let plugin_desc = match &cfg.desc {
-		Some(desc) => zyn! { Some({{ desc}}) },
-		None => zyn! { None },
+	let plugin_desc = match cfg.desc {
+		Some(desc) => quote!(Some(#desc)),
+		None => quote!(None),
 	};
-	let plugin_prefix = match &cfg.prefix {
-		Some(prefix) => zyn! { Some({{ prefix }}) },
-		None => zyn! { None },
+	let plugin_prefix = match cfg.prefix {
+		Some(prefix) => quote!(Some(#prefix)),
+		None => quote!(None),
 	};
-	let plugin_name = zyn! { env!("CARGO_PKG_NAME") };
-	let version_major = zyn! { env!("CARGO_PKG_VERSION_MAJOR").parse::<u64>().unwrap() };
-	let version_minor = zyn! { env!("CARGO_PKG_VERSION_MINOR").parse::<u64>().unwrap() };
-	let version_patch = zyn! { env!("CARGO_PKG_VERSION_PATCH").parse::<u64>().unwrap() };
 	let fn_name = &item.sig.ident;
-	let plugin_author = zyn! {
-		{
-			let authors = env!("CARGO_PKG_AUTHORS");
-			if authors.is_empty() {
-				::std::vec![]
-			} else {
-				authors.split(':').map(|author| author.trim()).collect::<::std::vec::Vec<&'static str>>()
+	let server_impl = match cfg.server {
+		Some(server) => quote! {
+			fn server(&self) -> Option<::puniyu_plugin::__private::ServerFunction> {
+				Some(::puniyu_plugin::__private::ServerFunction::new(#server))
 			}
-		}
+		},
+		None => quote! {},
 	};
 	let init_call = if item.block.stmts.is_empty() {
-		zyn! {}
+		quote! {}
 	} else {
-		zyn! {
+		quote! {
 			#[inline]
 			async fn init(&self) -> ::puniyu_plugin::Result {
-				{{ fn_name }}().await
+				#fn_name().await
 			}
 		}
 	};
 
-	zyn! {
-		{{ item }}
+	quote! {
+		#item
 
 		pub struct Plugin;
 
 		#[::puniyu_plugin::__private::async_trait]
 		impl ::puniyu_plugin::__private::Plugin for Plugin {
 			fn name(&self) -> &str {
-				#plugin_name
+				env!("CARGO_PKG_NAME")
 			}
 
 			fn version(&self) -> ::puniyu_plugin::Version {
 				::puniyu_plugin::Version {
-					major: {{ version_major }},
-					minor: {{ version_minor }},
-					patch: {{ version_patch }},
+					major: env!("CARGO_PKG_VERSION_MAJOR").parse::<u64>().unwrap(),
+					minor: env!("CARGO_PKG_VERSION_MINOR").parse::<u64>().unwrap(),
+					patch: env!("CARGO_PKG_VERSION_PATCH").parse::<u64>().unwrap(),
 				}
 			}
 
-			fn author(&self) -> Vec<&str> {
-				#plugin_author
+			fn author(&self) -> ::std::vec::Vec<&str> {
+				let authors = env!("CARGO_PKG_AUTHORS");
+				if authors.is_empty() {
+					::std::vec![]
+				} else {
+					authors.split(':').map(|author| author.trim()).collect::<::std::vec::Vec<&'static str>>()
+				}
 			}
 
 			fn description(&self) -> Option<&str> {
@@ -87,82 +87,65 @@ pub fn plugin(item: zyn::syn::ItemFn, cfg: PluginArg) -> zyn::TokenStream {
 				#plugin_prefix
 			}
 
-			fn tasks(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Task>> {
+			fn tasks(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Task>> {
 				::puniyu_plugin::__private::inventory::iter::<TaskRegistry>
 					.into_iter()
-					.filter(|task| task.plugin_name == {{ plugin_name }})
+					.filter(|task| task.plugin_name == env!("CARGO_PKG_NAME"))
 					.map(|task| (task.builder)())
 					.collect()
 			}
 
-			fn commands(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Command>> {
+			fn commands(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Command>> {
 				::puniyu_plugin::__private::inventory::iter::<CommandRegistry>
 					.into_iter()
-					.filter(|command| command.plugin_name == {{ plugin_name}})
+					.filter(|command| command.plugin_name == env!("CARGO_PKG_NAME"))
 					.map(|command| (command.builder)())
 					.collect()
 			}
 
-			fn hooks(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Hook>> {
+			fn hooks(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Hook>> {
 				::puniyu_plugin::__private::inventory::iter::<HookRegistry>
 					.into_iter()
-					.filter(|hook| hook.plugin_name == {{ plugin_name}})
+					.filter(|hook| hook.plugin_name == env!("CARGO_PKG_NAME"))
 					.map(|hook| (hook.builder)())
 					.collect()
 			}
 
-			fn config(&self) -> Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Config>> {
+			fn config(&self) -> ::std::vec::Vec<::std::sync::Arc<dyn ::puniyu_plugin::__private::Config>> {
 				::puniyu_plugin::__private::inventory::iter::<ConfigRegistry>
 					.into_iter()
-					.filter(|config| config.plugin_name == {{ plugin_name}})
+					.filter(|config| config.plugin_name == env!("CARGO_PKG_NAME"))
 					.map(|config| (config.builder)())
 					.collect()
 			}
 
-			fn server(&self) -> Option<::puniyu_plugin::__private::ServerFunction> {
-					@if(cfg.server.is_some()){
-						::puniyu_plugin::__private::ServerFunction::new(&cfg.server)
-					}
-					@else{
-						None
-					}
-			}
+			#server_impl
 
-			{{ init_call }}
+			#init_call
 		}
 
-		/// 定时计划注册表
 		pub(crate) struct TaskRegistry {
-			/// 插件名称
 			plugin_name: &'static str,
-			/// 任务构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Task>,
 		}
 		::puniyu_plugin::__private::inventory::collect!(crate::TaskRegistry);
 
 		pub(crate) struct CommandRegistry {
 			plugin_name: &'static str,
-			/// 命令构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Command>,
 		}
 		::puniyu_plugin::__private::inventory::collect!(crate::CommandRegistry);
 
-		/// 配置注册表
 		pub(crate) struct ConfigRegistry {
 			plugin_name: &'static str,
-			/// 配置构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Config>,
 		}
 		::puniyu_plugin::__private::inventory::collect!(crate::ConfigRegistry);
 
-		/// 钩子注册注册表
 		pub(crate) struct HookRegistry {
 			plugin_name: &'static str,
-			/// 钩子构造器
 			builder: fn() -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Hook>,
 		}
 		::puniyu_plugin::__private::inventory::collect!(crate::HookRegistry);
-
 	}
-	.to_token_stream()
 }

--- a/crates/puniyu_macros/src/plugin/command.rs
+++ b/crates/puniyu_macros/src/plugin/command.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ArgType, CommandArgs,
-	common::{function_struct_ident, path_matches, validate_async},
+	common::{default_name_from_ident, function_struct_ident, path_matches, validate_async},
 };
 use quote::{ToTokens, quote};
 use syn::{Attribute, ItemFn, Signature, Type, spanned::Spanned};
@@ -24,7 +24,7 @@ pub fn command(mut item: ItemFn, cfg: CommandArgs) -> proc_macro2::TokenStream {
 
 	let fn_name = &item.sig.ident;
 	let struct_name = function_struct_ident(fn_name, "Command");
-	let command_name = cfg.name;
+	let command_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
 	let command_priority = cfg.priority.unwrap_or(500u32);
 	let command_desc = match cfg.desc {
 		Some(desc) => quote!(Some(#desc)),
@@ -144,7 +144,7 @@ fn build_arg_tokens(args: &[ArgType]) -> syn::Result<Vec<proc_macro2::TokenStrea
 			let mode_method = if let Some(mode) = &arg.mode {
 				match mode.value().as_str() {
 					"positional" => quote!(.positional()),
-					"named" | "optional" => quote!(.named()),
+					"named" => quote!(.named()),
 					invalid => {
 						return Err(syn::Error::new_spanned(
 							mode,

--- a/crates/puniyu_macros/src/plugin/command.rs
+++ b/crates/puniyu_macros/src/plugin/command.rs
@@ -30,18 +30,22 @@ pub fn command(mut item: ItemFn, cfg: CommandArgs) -> proc_macro2::TokenStream {
 		Some(desc) => quote!(Some(#desc)),
 		None => quote!(None),
 	};
-	let command_permission = match cfg.permission.as_deref().unwrap_or("all") {
-		"all" => quote!(::puniyu_plugin::command::Permission::All),
-		"master" => quote!(::puniyu_plugin::command::Permission::Master),
-		"owner" => quote!(::puniyu_plugin::command::Permission::Owner),
-		"admin" => quote!(::puniyu_plugin::command::Permission::Admin),
-		invalid => {
-			return syn::Error::new_spanned(
-				&item.sig.ident,
-				format!("invalid command permission: {invalid}"),
-			)
-			.to_compile_error();
+	let command_permission = if let Some(permission) = &cfg.permission {
+		match permission.value().as_str() {
+			"all" => quote!(::puniyu_plugin::command::Permission::All),
+			"master" => quote!(::puniyu_plugin::command::Permission::Master),
+			"owner" => quote!(::puniyu_plugin::command::Permission::Owner),
+			"admin" => quote!(::puniyu_plugin::command::Permission::Admin),
+			invalid => {
+				return syn::Error::new_spanned(
+					permission,
+					format!("invalid command permission: {invalid}"),
+				)
+				.to_compile_error();
+			}
 		}
+	} else {
+		quote!(::puniyu_plugin::command::Permission::All)
 	};
 	let command_alias = cfg.alias.unwrap_or_default();
 	let args_tokens = match build_arg_tokens(&args) {
@@ -121,33 +125,38 @@ fn build_arg_tokens(args: &[ArgType]) -> syn::Result<Vec<proc_macro2::TokenStrea
 	args.iter()
 		.map(|arg| {
 			let name = &arg.name;
-			let constructor = match arg.arg_type.as_deref().unwrap_or("string") {
-				"string" => quote!(::puniyu_plugin::command::Arg::string(#name)),
-				"integer" | "int" => quote!(::puniyu_plugin::command::Arg::int(#name)),
-				"float" => quote!(::puniyu_plugin::command::Arg::float(#name)),
-				"boolean" | "bool" => quote!(::puniyu_plugin::command::Arg::bool(#name)),
-				invalid => {
-					return Err(syn::Error::new(
-						proc_macro2::Span::call_site(),
-						format!("invalid arg type: {invalid}"),
-					));
+			let constructor = if let Some(arg_type) = &arg.arg_type {
+				match arg_type.value().as_str() {
+					"string" => quote!(::puniyu_plugin::command::Arg::string(#name)),
+					"integer" | "int" => quote!(::puniyu_plugin::command::Arg::int(#name)),
+					"float" => quote!(::puniyu_plugin::command::Arg::float(#name)),
+					"boolean" | "bool" => quote!(::puniyu_plugin::command::Arg::bool(#name)),
+					invalid => {
+						return Err(syn::Error::new_spanned(
+							arg_type,
+							format!("invalid arg type: {invalid}"),
+						));
+					}
 				}
-			};
-			let mode_method = match arg.mode.as_deref().unwrap_or("positional") {
-				"positional" => quote!(.positional()),
-				"named" | "optional" => quote!(.named()),
-				invalid => {
-					return Err(syn::Error::new(
-						proc_macro2::Span::call_site(),
-						format!("invalid arg mode: {invalid}"),
-					));
-				}
-			};
-			let required_method = if arg.required.unwrap_or(false) {
-				quote!(.required())
 			} else {
-				quote!()
+				quote!(::puniyu_plugin::command::Arg::string(#name))
 			};
+			let mode_method = if let Some(mode) = &arg.mode {
+				match mode.value().as_str() {
+					"positional" => quote!(.positional()),
+					"named" | "optional" => quote!(.named()),
+					invalid => {
+						return Err(syn::Error::new_spanned(
+							mode,
+							format!("invalid arg mode: {invalid}"),
+						));
+					}
+				}
+			} else {
+				quote!(.positional())
+			};
+			let required_method =
+				if arg.required.unwrap_or(false) { quote!(.required()) } else { quote!() };
 			let desc_method = match &arg.desc {
 				Some(desc) => quote!(.description(#desc)),
 				None => quote!(),
@@ -158,7 +167,10 @@ fn build_arg_tokens(args: &[ArgType]) -> syn::Result<Vec<proc_macro2::TokenStrea
 }
 
 fn validate_command_args(fn_sig: &Signature) -> syn::Result<()> {
-	let arg_type = crate::common::validate_single_ref_arg(fn_sig, "command function parameter must not be `self`")?;
+	let arg_type = crate::common::validate_single_ref_arg(
+		fn_sig,
+		"command function parameter must not be `self`",
+	)?;
 	if !path_matches(arg_type, &["MessageContext"])
 		&& !path_matches(arg_type, &["puniyu_context", "MessageContext"])
 		&& !path_matches(arg_type, &["puniyu_plugin", "context", "MessageContext"])

--- a/crates/puniyu_macros/src/plugin/command.rs
+++ b/crates/puniyu_macros/src/plugin/command.rs
@@ -1,7 +1,11 @@
-use crate::{ArgType, CommandArgs, common::validate_async};
-use zyn::{ToTokens, zyn};
+use crate::{
+	ArgType, CommandArgs,
+	common::{function_struct_ident, path_matches, validate_async},
+};
+use quote::{ToTokens, quote};
+use syn::{Attribute, ItemFn, Signature, Type, spanned::Spanned};
 
-pub fn command(item: zyn::syn::ItemFn, cfg: CommandArgs) -> zyn::TokenStream {
+pub fn command(mut item: ItemFn, cfg: CommandArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
 	if let Err(err) = validate_async(&fn_sig) {
 		return err.to_compile_error();
@@ -13,94 +17,45 @@ pub fn command(item: zyn::syn::ItemFn, cfg: CommandArgs) -> zyn::TokenStream {
 		return err.to_compile_error();
 	}
 
-	let fn_name = &item.sig.ident;
-	let struct_name = zyn! { {{ fn_name | pascal | ident: "{}Command" }} };
-	let plugin_name = zyn! { env!("CARGO_PKG_NAME") };
-	let command_name = zyn! { {{ cfg.name | str }} };
-	let command_priority = match cfg.priority {
-		Some(p) => zyn! { {{ p }} },
-		None => zyn! { 500u32 },
+	let args = match collect_arg_attrs(&mut item.attrs) {
+		Ok(args) => args,
+		Err(err) => return err.to_compile_error(),
 	};
-	let command_desc = match &cfg.desc {
-		Some(desc) => zyn! { Some({{ desc | str }}) },
-		None => zyn! { None },
+
+	let fn_name = &item.sig.ident;
+	let struct_name = function_struct_ident(fn_name, "Command");
+	let command_name = cfg.name;
+	let command_priority = cfg.priority.unwrap_or(500u32);
+	let command_desc = match cfg.desc {
+		Some(desc) => quote!(Some(#desc)),
+		None => quote!(None),
 	};
 	let command_permission = match cfg.permission.as_deref().unwrap_or("all") {
-		"all" => zyn! { ::puniyu_plugin::command::Permission::All },
-		"master" => zyn! { ::puniyu_plugin::command::Permission::Master },
-		"owner" => zyn! { ::puniyu_plugin::command::Permission::Owner },
-		"admin" => zyn! { ::puniyu_plugin::command::Permission::Admin },
+		"all" => quote!(::puniyu_plugin::command::Permission::All),
+		"master" => quote!(::puniyu_plugin::command::Permission::Master),
+		"owner" => quote!(::puniyu_plugin::command::Permission::Owner),
+		"admin" => quote!(::puniyu_plugin::command::Permission::Admin),
 		invalid => {
-			return zyn::syn::Error::new_spanned(
+			return syn::Error::new_spanned(
 				&item.sig.ident,
 				format!("invalid command permission: {invalid}"),
 			)
 			.to_compile_error();
 		}
 	};
-	let command_alias = {
-		let aliases = cfg.alias.as_deref().unwrap_or(&[]);
-		if aliases.is_empty() {
-			zyn! { ::std::vec![] }
-		} else {
-			let mut ts = zyn::TokenStream::new();
-			for alias in aliases {
-				ts.extend(zyn! { {{ alias }}, }.to_token_stream());
-			}
-			zyn! { ::std::vec![{{ ts }}] }
-		}
-	};
-	let args_tokens = {
-		let mut ts = zyn::TokenStream::new();
-		for attr in &item.attrs {
-			if !attr.path().is_ident("arg") {
-				continue;
-			}
-			let list = match attr.meta.require_list() {
-				Ok(l) => l,
-				Err(e) => return e.to_compile_error(),
-			};
-			let args: zyn::meta::Args = match zyn::syn::parse2(list.tokens.clone()) {
-				Ok(a) => a,
-				Err(e) => return e.to_compile_error(),
-			};
-			let arg = match ArgType::from_args(&args) {
-				Ok(a) => a,
-				Err(e) => return e.emit_as_item_tokens(),
-			};
-			let arg_name = &arg.name;
-			let constructor = match arg.arg_type.as_deref().unwrap_or("string") {
-				"integer" => zyn! { ::puniyu_plugin::command::Arg::integer({{ arg_name | str }}) },
-				"boolean" => zyn! { ::puniyu_plugin::command::Arg::boolean({{ arg_name | str }}) },
-				_ => zyn! { ::puniyu_plugin::command::Arg::string({{ arg_name | str }}) },
-			};
-			let mode_method = match arg.mode.as_deref().unwrap_or("positional") {
-				"optional" => zyn! { .optional() },
-				_ => zyn! { .positional() },
-			};
-			let required_method = if arg.required.unwrap_or(false) {
-				zyn! { .required() }.to_token_stream()
-			} else {
-				zyn::TokenStream::new()
-			};
-			let desc_method = match &arg.desc {
-				Some(desc) => zyn! { .description({{ desc | str }}) }.to_token_stream(),
-				None => zyn::TokenStream::new(),
-			};
-			ts.extend(
-				zyn! { #constructor #mode_method #required_method #desc_method, }.to_token_stream(),
-			);
-		}
-		ts
+	let command_alias = cfg.alias.unwrap_or_default();
+	let args_tokens = match build_arg_tokens(&args) {
+		Ok(tokens) => tokens,
+		Err(err) => return err.to_compile_error(),
 	};
 
-	zyn! {
-		{{ item }}
+	quote! {
+		#item
 
-		struct {{ struct_name }};
+		struct #struct_name;
 
 		#[::puniyu_plugin::__private::async_trait]
-		impl ::puniyu_plugin::__private::Command for {{ struct_name }} {
+		impl ::puniyu_plugin::__private::Command for #struct_name {
 			fn name(&self) -> &str {
 				#command_name
 			}
@@ -114,11 +69,11 @@ pub fn command(item: zyn::syn::ItemFn, cfg: CommandArgs) -> zyn::TokenStream {
 			}
 
 			fn args(&self) -> ::std::vec::Vec<::puniyu_plugin::command::Arg<'_>> {
-				::std::vec![{{ args_tokens }}]
+				::std::vec![#(#args_tokens),*]
 			}
 
 			fn alias(&self) -> ::std::vec::Vec<&str> {
-				#command_alias
+				::std::vec![#(#command_alias),*]
 			}
 
 			fn permission(&self) -> ::puniyu_plugin::command::Permission {
@@ -130,85 +85,103 @@ pub fn command(item: zyn::syn::ItemFn, cfg: CommandArgs) -> zyn::TokenStream {
 				&self,
 				ctx: &::puniyu_plugin::context::MessageContext,
 			) -> ::puniyu_plugin::Result<::puniyu_plugin::command::CommandAction> {
-				{{ fn_name }}(ctx).await
+				#fn_name(ctx).await
 			}
 		}
 
 		::puniyu_plugin::__private::inventory::submit! {
 			crate::CommandRegistry {
-				plugin_name: {{ plugin_name }},
+				plugin_name: env!("CARGO_PKG_NAME"),
 				builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Command> {
-					::std::sync::Arc::new({{ struct_name }} {})
+					::std::sync::Arc::new(#struct_name {})
 				}
 			}
 		}
 	}
-	.to_token_stream()
 }
 
-fn validate_command_args(fn_sig: &zyn::syn::Signature) -> zyn::syn::Result<()> {
-	use zyn::syn::spanned::Spanned;
-	let fn_name = &fn_sig.ident;
-	let inputs = &fn_sig.inputs;
-	if inputs.len() != 1 {
-		return Err(zyn::syn::Error::new(
-			fn_sig.span(),
-			format!("function `{}` must have exactly 1 parameter, found {}", fn_name, inputs.len()),
-		));
+fn collect_arg_attrs(attrs: &mut Vec<Attribute>) -> syn::Result<Vec<ArgType>> {
+	let mut parsed = Vec::new();
+	let mut retained = Vec::new();
+
+	for attr in attrs.drain(..) {
+		if attr.path().is_ident("arg") {
+			let arg = attr.parse_args::<ArgType>()?;
+			parsed.push(arg);
+		} else {
+			retained.push(attr);
+		}
 	}
-	let arg = inputs.first().unwrap();
-	let pat_type = match arg {
-		zyn::syn::FnArg::Typed(pt) => pt,
-		zyn::syn::FnArg::Receiver(_) => {
-			return Err(zyn::syn::Error::new(
-				arg.span(),
-				"command function parameter must not be `self`",
-			));
-		}
-	};
-	let inner_type = match pat_type.ty.as_ref() {
-		zyn::syn::Type::Reference(r) => &r.elem,
-		_ => {
-			return Err(zyn::syn::Error::new(
-				pat_type.ty.span(),
-				"command function parameter must be a reference: `&MessageContext`",
-			));
-		}
-	};
-	let is_valid = match inner_type.as_ref() {
-		zyn::syn::Type::Path(tp) => {
-			let last = tp.path.segments.last().map(|s| s.ident.to_string());
-			let full = tp.path.to_token_stream().to_string().replace(' ', "");
-			last.as_deref() == Some("MessageContext")
-				|| matches!(
-					full.as_str(),
-					"puniyu_plugin::context::MessageContext"
-						| "::puniyu_plugin::context::MessageContext"
-				)
-		}
-		_ => false,
-	};
-	if !is_valid {
-		return Err(zyn::syn::Error::new(
-			inner_type.span(),
-			"command function parameter type must be `MessageContext` or `puniyu_plugin::context::MessageContext`",
+
+	*attrs = retained;
+	Ok(parsed)
+}
+
+fn build_arg_tokens(args: &[ArgType]) -> syn::Result<Vec<proc_macro2::TokenStream>> {
+	args.iter()
+		.map(|arg| {
+			let name = &arg.name;
+			let constructor = match arg.arg_type.as_deref().unwrap_or("string") {
+				"string" => quote!(::puniyu_plugin::command::Arg::string(#name)),
+				"integer" | "int" => quote!(::puniyu_plugin::command::Arg::int(#name)),
+				"float" => quote!(::puniyu_plugin::command::Arg::float(#name)),
+				"boolean" | "bool" => quote!(::puniyu_plugin::command::Arg::bool(#name)),
+				invalid => {
+					return Err(syn::Error::new(
+						proc_macro2::Span::call_site(),
+						format!("invalid arg type: {invalid}"),
+					));
+				}
+			};
+			let mode_method = match arg.mode.as_deref().unwrap_or("positional") {
+				"positional" => quote!(.positional()),
+				"named" | "optional" => quote!(.named()),
+				invalid => {
+					return Err(syn::Error::new(
+						proc_macro2::Span::call_site(),
+						format!("invalid arg mode: {invalid}"),
+					));
+				}
+			};
+			let required_method = if arg.required.unwrap_or(false) {
+				quote!(.required())
+			} else {
+				quote!()
+			};
+			let desc_method = match &arg.desc {
+				Some(desc) => quote!(.description(#desc)),
+				None => quote!(),
+			};
+			Ok(quote!(#constructor #mode_method #required_method #desc_method))
+		})
+		.collect()
+}
+
+fn validate_command_args(fn_sig: &Signature) -> syn::Result<()> {
+	let arg_type = crate::common::validate_single_ref_arg(fn_sig, "command function parameter must not be `self`")?;
+	if !path_matches(arg_type, &["MessageContext"])
+		&& !path_matches(arg_type, &["puniyu_context", "MessageContext"])
+		&& !path_matches(arg_type, &["puniyu_plugin", "context", "MessageContext"])
+	{
+		return Err(syn::Error::new(
+			arg_type.span(),
+			"command function parameter type must be `MessageContext`, `puniyu_plugin::context::MessageContext` or `puniyu_context::MessageContext`",
 		));
 	}
 	Ok(())
 }
 
-fn validate_command_return_type(fn_sig: &zyn::syn::Signature) -> zyn::syn::Result<()> {
-	use zyn::syn::spanned::Spanned;
+fn validate_command_return_type(fn_sig: &Signature) -> syn::Result<()> {
 	let err = |span| {
-		Err(zyn::syn::Error::new(
+		Err(syn::Error::new(
 			span,
 			"command function must return `puniyu_plugin::Result<CommandAction>` or `puniyu_plugin::Result<puniyu_plugin::command::CommandAction>`",
 		))
 	};
-	let zyn::syn::ReturnType::Type(_, ty) = &fn_sig.output else {
+	let syn::ReturnType::Type(_, ty) = &fn_sig.output else {
 		return err(fn_sig.span());
 	};
-	let zyn::syn::Type::Path(tp) = ty.as_ref() else {
+	let Type::Path(tp) = ty.as_ref() else {
 		return err(ty.span());
 	};
 	let actual = tp.path.to_token_stream().to_string().replace(' ', "");

--- a/crates/puniyu_macros/src/plugin/command.rs
+++ b/crates/puniyu_macros/src/plugin/command.rs
@@ -109,7 +109,7 @@ fn collect_arg_attrs(attrs: &mut Vec<Attribute>) -> syn::Result<Vec<ArgType>> {
 	let mut retained = Vec::new();
 
 	for attr in attrs.drain(..) {
-		if attr.path().is_ident("arg") {
+		if attr.path().is_ident("arg") || attr.path().is_ident("__puniyu_arg") {
 			let arg = attr.parse_args::<ArgType>()?;
 			parsed.push(arg);
 		} else {

--- a/crates/puniyu_macros/src/plugin/config.rs
+++ b/crates/puniyu_macros/src/plugin/config.rs
@@ -1,45 +1,38 @@
-use crate::ConfigArgs;
-use zyn::{ToTokens, zyn};
+use crate::{ConfigArgs, common::config_name};
+use quote::quote;
+use syn::ItemStruct;
 
-pub fn config(item: zyn::syn::ItemStruct, cfg: ConfigArgs) -> zyn::TokenStream {
+pub fn config(item: ItemStruct, cfg: ConfigArgs) -> proc_macro2::TokenStream {
 	let struct_name = &item.ident;
-	let config_name = match &cfg.name {
-		Some(name) => zyn! { {{ name | snake | str }}},
-		None => zyn! { {{ struct_name | snake | str }}},
-	};
-	let config_file_name = zyn! { {{ config_name | snake | fmt: "{}.toml" }}}.to_string();
-	let serialize_error = match &cfg.name {
-		Some(name) => zyn! { {{ name | snake | fmt: "Failed to serialize {} to TOML string" }}},
-		None => zyn! { {{ struct_name | snake | fmt: "Failed to serialize {} to TOML string" }}},
-	};
+	let config_name = config_name(cfg.name.as_deref(), struct_name);
+	let config_file_name = format!("{config_name}.toml");
+	let serialize_error = format!("Failed to serialize {config_name} to TOML string");
 
-	let plugin_name = zyn! { env!("CARGO_PKG_NAME") };
+	quote! {
+		#item
 
-	zyn! {
-			{{ item }}
-
-	impl ::puniyu_plugin::__private::Config for {{ struct_name }} {
-				fn config(&self) -> ::puniyu_plugin::__private::ConfigInfo {
-					::puniyu_plugin::__private::ConfigInfo {
-						name: ::std::string::String::from({{ config_name }}),
-						path: ::puniyu_plugin::path::adapter::config_dir()
-							.join({{ plugin_name }})
-							.join({{ config_file_name }}),
-						value: ::puniyu_plugin::__private::toml::from_str(
-							&::puniyu_plugin::__private::toml::to_string(self).expect({{ serialize_error }}),
-						).expect("Failed to parse TOML string to Value"),
-					}
-				}
-			}
-
-			::puniyu_plugin::__private::inventory::submit! {
-				crate::ConfigRegistry {
-					plugin_name: {{ plugin_name }},
-					builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Config> {
-						::std::sync::Arc::new( {{ struct_name}}::default())
-					}
+		impl ::puniyu_plugin::__private::Config for #struct_name {
+			fn config(&self) -> ::puniyu_plugin::__private::ConfigInfo {
+				::puniyu_plugin::__private::ConfigInfo {
+					name: ::std::string::String::from(#config_name),
+					path: ::puniyu_plugin::path::adapter::config_dir()
+						.join(env!("CARGO_PKG_NAME"))
+						.join(#config_file_name),
+					value: ::puniyu_plugin::__private::toml::from_str(
+						&::puniyu_plugin::__private::toml::to_string(self).expect(#serialize_error),
+					)
+					.expect("Failed to parse TOML string to Value"),
 				}
 			}
 		}
-	.into_token_stream()
+
+		::puniyu_plugin::__private::inventory::submit! {
+			crate::ConfigRegistry {
+				plugin_name: env!("CARGO_PKG_NAME"),
+				builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Config> {
+					::std::sync::Arc::new(#struct_name::default())
+				}
+			}
+		}
+	}
 }

--- a/crates/puniyu_macros/src/plugin/config.rs
+++ b/crates/puniyu_macros/src/plugin/config.rs
@@ -15,7 +15,7 @@ pub fn config(item: ItemStruct, cfg: ConfigArgs) -> proc_macro2::TokenStream {
 			fn config(&self) -> ::puniyu_plugin::__private::ConfigInfo {
 				::puniyu_plugin::__private::ConfigInfo {
 					name: ::std::string::String::from(#config_name),
-					path: ::puniyu_plugin::path::adapter::config_dir()
+					path: ::puniyu_plugin::path::plugin::config_dir()
 						.join(env!("CARGO_PKG_NAME"))
 						.join(#config_file_name),
 					value: ::puniyu_plugin::__private::toml::from_str(

--- a/crates/puniyu_macros/src/plugin/hook.rs
+++ b/crates/puniyu_macros/src/plugin/hook.rs
@@ -1,9 +1,12 @@
 use crate::{
 	HookArgs,
-	common::{default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async, validate_hook_args, validate_return_type},
+	common::{
+		default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async,
+		validate_hook_args, validate_return_type,
+	},
 };
 use quote::quote;
-use syn::{ItemFn, spanned::Spanned};
+use syn::{ItemFn, LitStr, spanned::Spanned};
 
 pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
@@ -20,7 +23,9 @@ pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_name = &fn_sig.ident;
 	let struct_name = function_struct_ident(fn_name, "Hook");
 	let hook_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
-	let hook_type = match hook_type_tokens("plugin", cfg.hook_type.as_deref(), fn_sig.span()) {
+	let hook_type_value = cfg.hook_type.as_ref().map(LitStr::value);
+	let hook_type_span = cfg.hook_type.as_ref().map_or_else(|| fn_sig.span(), LitStr::span);
+	let hook_type = match hook_type_tokens("plugin", hook_type_value.as_deref(), hook_type_span) {
 		Ok(tokens) => tokens,
 		Err(err) => return err.to_compile_error(),
 	};

--- a/crates/puniyu_macros/src/plugin/hook.rs
+++ b/crates/puniyu_macros/src/plugin/hook.rs
@@ -1,10 +1,11 @@
 use crate::{
 	HookArgs,
-	common::{validate_async, validate_hook_args, validate_return_type},
+	common::{default_name_from_ident, function_struct_ident, hook_type_tokens, validate_async, validate_hook_args, validate_return_type},
 };
-use zyn::{ToTokens, syn::spanned::Spanned, zyn};
+use quote::quote;
+use syn::{ItemFn, spanned::Spanned};
 
-pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
+pub fn hook(item: ItemFn, cfg: HookArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
 	if let Err(err) = validate_async(&fn_sig) {
 		return err.to_compile_error();
@@ -17,113 +18,29 @@ pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
 	}
 
 	let fn_name = &fn_sig.ident;
-	let struct_name = zyn! { {{ fn_name | pascal | ident: "{}Hook" }} };
-	let plugin_name = zyn! { env!("CARGO_PKG_NAME") };
-	let hook_name = match &cfg.name {
-		Some(name) => zyn! { {{ name | str }} },
-		_ => zyn! { {{ fn_name | lower | str }} },
+	let struct_name = function_struct_ident(fn_name, "Hook");
+	let hook_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
+	let hook_type = match hook_type_tokens("plugin", cfg.hook_type.as_deref(), fn_sig.span()) {
+		Ok(tokens) => tokens,
+		Err(err) => return err.to_compile_error(),
 	};
-	let hook_type = match &cfg.hook_type {
-		Some(type_str) => {
-			let parts: Vec<&str> = type_str.split('.').collect();
-			match parts.as_slice() {
-				["event"] => zyn! {
-					::puniyu_plugin::hook::HookType::Event(
-						::puniyu_plugin::hook::HookEventType::default()
-					)
-				},
-				["event", "message"] => zyn! {
-					::puniyu_plugin::hook::HookType::Event(
-						::puniyu_plugin::hook::HookEventType::Message
-					)
-				},
-				["event", "extension"] => zyn! {
-					::puniyu_plugin::hook::HookType::Event(
-						::puniyu_plugin::hook::HookEventType::Extension
-					)
-				},
-				["event", "all"] => zyn! {
-					::puniyu_plugin::hook::HookType::Event(
-						::puniyu_plugin::hook::HookEventType::All
-					)
-				},
-				["status"] => zyn! {
-					::puniyu_plugin::hook::HookType::Status(
-						::puniyu_plugin::hook::StatusType::default()
-					)
-				},
-				["status", "start"] => zyn! {
-					::puniyu_plugin::hook::HookType::Status(
-						::puniyu_plugin::hook::StatusType::Start
-					)
-				},
-				["status", "stop"] => zyn! {
-					::puniyu_plugin::hook::HookType::Status(
-						::puniyu_plugin::hook::StatusType::Stop
-					)
-				},
-				["event", subtype] => {
-					let err_msg = format!(
-						"Invalid event subtype '{}'. Valid event subtypes are: 'message', 'extension', 'all'. \
-						Examples: 'event.message', 'event.all'",
-						subtype
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				["status", subtype] => {
-					let err_msg = format!(
-						"Invalid status subtype '{}'. Valid status subtypes are: 'start', 'stop'. \
-						Examples: 'status.start', 'status.stop'",
-						subtype
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				[category, _] => {
-					let err_msg = format!(
-						"Invalid hook category '{}'. Valid categories are: 'event', 'status'. \
-						Examples: 'event.message', 'status.start'",
-						category
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				[category] => {
-					let err_msg = format!(
-						"Invalid hook category '{}'. Valid categories are: 'event', 'status'. \
-						Examples: 'event', 'event.message', 'status.start'",
-						category
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-				_ => {
-					let err_msg = format!(
-						"Invalid hook type format '{}'. Expected format: 'category' or 'category.subtype'. \
-						Examples: 'event', 'event.message', 'status.start'",
-						type_str
-					);
-					return zyn::syn::Error::new(fn_sig.span(), err_msg).to_compile_error();
-				}
-			}
-		}
-		None => zyn! { ::puniyu_plugin::hook::HookType::default() },
-	};
-	let hook_priority = match &cfg.priority {
-		Some(priority) => zyn! { {{ priority }} },
-		_ => zyn! { 500 },
-	};
+	let hook_priority = cfg.priority.unwrap_or(500);
 
-	zyn! {
-		{{ item }}
+	quote! {
+		#item
 
-		struct {{ struct_name }};
+		struct #struct_name;
 
 		#[::puniyu_plugin::__private::async_trait]
-		impl ::puniyu_plugin::__private::Hook for {{ struct_name }} {
+		impl ::puniyu_plugin::__private::Hook for #struct_name {
 			fn name(&self) -> &'static str {
 				#hook_name
 			}
 
-			fn r#type(&self) -> ::puniyu_plugin::hook::HookType {
-				#hook_type
+			fn r#type(&self) -> &::puniyu_plugin::hook::HookType {
+				static HOOK_TYPE: ::std::sync::LazyLock<::puniyu_plugin::hook::HookType> =
+					::std::sync::LazyLock::new(|| #hook_type);
+				&HOOK_TYPE
 			}
 
 			fn priority(&self) -> u32 {
@@ -133,20 +50,19 @@ pub fn hook(item: zyn::syn::ItemFn, cfg: HookArgs) -> zyn::TokenStream {
 			#[inline]
 			async fn execute(
 				&self,
-				event: Option<&Event>,
+				_event: Option<&::puniyu_plugin::context::EventContext>,
 			) -> ::puniyu_plugin::Result {
-				{{ fn_name }}(event).await
+				#fn_name(self.r#type()).await
 			}
 		}
 
 		::puniyu_plugin::__private::inventory::submit! {
 			crate::HookRegistry {
-				plugin_name: {{ plugin_name }},
+				plugin_name: env!("CARGO_PKG_NAME"),
 				builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Hook> {
-					::std::sync::Arc::new({{ struct_name }} {})
+					::std::sync::Arc::new(#struct_name {})
 				}
 			}
 		}
 	}
-	.to_token_stream()
 }

--- a/crates/puniyu_macros/src/plugin/task.rs
+++ b/crates/puniyu_macros/src/plugin/task.rs
@@ -1,66 +1,62 @@
 use crate::{
 	TaskArgs,
-	common::{validate_async, validate_return_type},
+	common::{default_name_from_ident, function_struct_ident, validate_async, validate_return_type, validate_zero_args},
 };
 use croner::Cron;
+use quote::quote;
 use std::str::FromStr;
-use zyn::{ToTokens, zyn};
+use syn::{ItemFn, LitStr};
 
-pub fn task(item: zyn::syn::ItemFn, cfg: TaskArgs) -> zyn::TokenStream {
+pub fn task(item: ItemFn, cfg: TaskArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
 	if let Err(err) = validate_async(&fn_sig) {
+		return err.to_compile_error();
+	}
+	if let Err(err) = validate_zero_args(&fn_sig) {
 		return err.to_compile_error();
 	}
 	if let Err(err) = validate_return_type(&fn_sig, "puniyu_plugin::Result") {
 		return err.to_compile_error();
 	}
-	let fn_name = &item.sig.ident;
 
-	let cron_expr = &cfg.cron;
-	if Cron::from_str(cron_expr).is_err() {
-		return zyn::syn::Error::new_spanned(cron_expr, "Invalid cron expression format")
+	let fn_name = &item.sig.ident;
+	let cron_expr = cfg.cron;
+	if Cron::from_str(&cron_expr).is_err() {
+		return syn::Error::new_spanned(LitStr::new(&cron_expr, fn_sig.ident.span()), "Invalid cron expression format")
 			.to_compile_error();
 	}
 
-	let plugin_name = zyn! { env!("CARGO_PKG_NAME") };
-	let task_name = match cfg.name {
-		Some(name) => zyn! { {{ name }} },
-		None => {
-			zyn! { {{ fn_name | snake | str }}}
-		}
-	};
-	let struct_name = zyn! { {{ fn_name | pascal | ident: "{}Task" | str }} };
-	zyn! {
-			{{ item }}
+	let task_name = cfg.name.unwrap_or_else(|| default_name_from_ident(fn_name));
+	let struct_name = function_struct_ident(fn_name, "Task");
 
-			struct {{ struct_name }}
+	quote! {
+		#item
 
+		struct #struct_name;
 
-			#[::puniyu_plugin::__private::async_trait]
-			impl ::puniyu_plugin::___private::Task for {{ struct_name } {
-				fn name(&self) -> &str {
-					#task_name
-				}
-
-				fn cron(&self) -> &str {
-					#cron_expr
-				}
-
-				#[inline]
-				async fn execute(&self) -> ::puniyu_plugin::Result {
-					{{ fn_name}}().await
-				}
+		#[::puniyu_plugin::__private::async_trait]
+		impl ::puniyu_plugin::__private::Task for #struct_name {
+			fn name(&self) -> &'static str {
+				#task_name
 			}
 
-			::puniyu_plugin::__private::inventory::submit! {
-				crate::TaskRegistry {
-					plugin_name: {{ plugin_name}},
-					builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Task> {
-						::std::sync::Arc::new({{ struct_name }} {})
-					},
-				}
+			fn cron(&self) -> &'static str {
+				#cron_expr
+			}
+
+			#[inline]
+			async fn execute(&self) -> ::puniyu_plugin::Result {
+				#fn_name().await
+			}
+		}
+
+		::puniyu_plugin::__private::inventory::submit! {
+			crate::TaskRegistry {
+				plugin_name: env!("CARGO_PKG_NAME"),
+				builder: || -> ::std::sync::Arc<dyn ::puniyu_plugin::__private::Task> {
+					::std::sync::Arc::new(#struct_name {})
+				},
 			}
 		}
 	}
-	.to_token_stream()
 }

--- a/crates/puniyu_macros/src/plugin/task.rs
+++ b/crates/puniyu_macros/src/plugin/task.rs
@@ -1,11 +1,14 @@
 use crate::{
 	TaskArgs,
-	common::{default_name_from_ident, function_struct_ident, validate_async, validate_return_type, validate_zero_args},
+	common::{
+		default_name_from_ident, function_struct_ident, validate_async, validate_return_type,
+		validate_zero_args,
+	},
 };
 use croner::Cron;
 use quote::quote;
 use std::str::FromStr;
-use syn::{ItemFn, LitStr};
+use syn::ItemFn;
 
 pub fn task(item: ItemFn, cfg: TaskArgs) -> proc_macro2::TokenStream {
 	let fn_sig = item.sig.clone();
@@ -21,8 +24,8 @@ pub fn task(item: ItemFn, cfg: TaskArgs) -> proc_macro2::TokenStream {
 
 	let fn_name = &item.sig.ident;
 	let cron_expr = cfg.cron;
-	if Cron::from_str(&cron_expr).is_err() {
-		return syn::Error::new_spanned(LitStr::new(&cron_expr, fn_sig.ident.span()), "Invalid cron expression format")
+	if Cron::from_str(&cron_expr.value()).is_err() {
+		return syn::Error::new_spanned(&cron_expr, "Invalid cron expression format")
 			.to_compile_error();
 	}
 

--- a/crates/puniyu_macros/src/types.rs
+++ b/crates/puniyu_macros/src/types.rs
@@ -1,62 +1,304 @@
-#[derive(zyn::Attribute)]
-#[zyn("config")]
+use syn::{Expr, LitBool, LitInt, LitStr, Result, Token, bracketed, parse::{Parse, ParseStream}};
+
 pub(crate) struct ConfigArgs {
-	#[zyn(default)]
 	pub name: Option<String>,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("adapter")]
 pub(crate) struct AdapterArgs {
-	pub runtime: zyn::syn::Expr,
-	#[zyn(default)]
-	pub server: Option<zyn::syn::Expr>,
+	pub runtime: Expr,
+	pub server: Option<Expr>,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("hook")]
 pub(crate) struct HookArgs {
-	#[zyn(default)]
 	pub name: Option<String>,
-	#[zyn("type")]
 	pub hook_type: Option<String>,
-	#[zyn(default = "500")]
 	pub priority: Option<u32>,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("plugin")]
 pub(crate) struct PluginArg {
 	pub desc: Option<String>,
 	pub prefix: Option<String>,
-	pub server: Option<zyn::syn::Expr>,
+	pub server: Option<Expr>,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("task")]
 pub(crate) struct TaskArgs {
 	pub name: Option<String>,
 	pub cron: String,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("arg")]
 pub(crate) struct ArgType {
 	pub name: String,
-	#[zyn("type")]
 	pub arg_type: Option<String>,
 	pub mode: Option<String>,
 	pub required: Option<bool>,
 	pub desc: Option<String>,
 }
 
-#[derive(zyn::Attribute)]
-#[zyn("command")]
 pub(crate) struct CommandArgs {
 	pub name: String,
 	pub priority: Option<u32>,
 	pub desc: Option<String>,
-	pub alias: Option<Vec<zyn::syn::LitStr>>,
-	#[zyn(default = "all")]
+	pub alias: Option<Vec<String>>,
 	pub permission: Option<String>,
 }
+
+impl ConfigArgs {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl AdapterArgs {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl HookArgs {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl PluginArg {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl TaskArgs {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl CommandArgs {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
+impl Parse for ConfigArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut name = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self { name })
+	}
+}
+
+impl Parse for AdapterArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut runtime = None;
+		let mut server = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"runtime" => assign_option(&mut runtime, key, parser.parse_expr()?)?,
+				"server" => assign_option(&mut server, key, parser.parse_expr()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self { runtime: require_field(runtime, "runtime")?, server })
+	}
+}
+
+impl Parse for HookArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut name = None;
+		let mut hook_type = None;
+		let mut priority = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
+				"hook_type" | "type" | "r#type" => {
+					assign_option(&mut hook_type, key, parser.parse_string()?)?
+				}
+				"priority" => assign_option(&mut priority, key, parser.parse_u32()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self { name, hook_type, priority })
+	}
+}
+
+impl Parse for PluginArg {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut desc = None;
+		let mut prefix = None;
+		let mut server = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"desc" => assign_option(&mut desc, key, parser.parse_string()?)?,
+				"prefix" => assign_option(&mut prefix, key, parser.parse_string()?)?,
+				"server" => assign_option(&mut server, key, parser.parse_expr()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self { desc, prefix, server })
+	}
+}
+
+impl Parse for TaskArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut name = None;
+		let mut cron = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
+				"cron" => assign_option(&mut cron, key, parser.parse_string()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self { name, cron: require_field(cron, "cron")? })
+	}
+}
+
+impl Parse for ArgType {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut name = None;
+		let mut arg_type = None;
+		let mut mode = None;
+		let mut required = None;
+		let mut desc = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
+				"arg_type" | "type" | "r#type" => {
+					assign_option(&mut arg_type, key, parser.parse_string()?)?
+				}
+				"mode" => assign_option(&mut mode, key, parser.parse_string()?)?,
+				"required" => assign_option(&mut required, key, parser.parse_bool()?)?,
+				"desc" => assign_option(&mut desc, key, parser.parse_string()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self {
+			name: require_field(name, "name")?,
+			arg_type,
+			mode,
+			required,
+			desc,
+		})
+	}
+}
+
+impl Parse for CommandArgs {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut parser = KeyValueParser::new(input);
+		let mut name = None;
+		let mut priority = None;
+		let mut desc = None;
+		let mut alias = None;
+		let mut permission = None;
+
+		while let Some(key) = parser.next_key()? {
+			match key.as_str() {
+				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
+				"priority" => assign_option(&mut priority, key, parser.parse_u32()?)?,
+				"desc" => assign_option(&mut desc, key, parser.parse_string()?)?,
+				"alias" => assign_option(&mut alias, key, parser.parse_string_array()?)?,
+				"permission" => assign_option(&mut permission, key, parser.parse_string()?)?,
+				_ => return Err(parser.unknown_key(&key)),
+			}
+		}
+
+		Ok(Self {
+			name: require_field(name, "name")?,
+			priority,
+			desc,
+			alias,
+			permission,
+		})
+	}
+}
+
+struct KeyValueParser<'a> {
+	input: ParseStream<'a>,
+}
+
+impl<'a> KeyValueParser<'a> {
+	fn new(input: ParseStream<'a>) -> Self {
+		Self { input }
+	}
+
+	fn next_key(&mut self) -> Result<Option<String>> {
+		while self.input.peek(Token![,]) {
+			self.input.parse::<Token![,]>()?;
+		}
+		if self.input.is_empty() {
+			return Ok(None);
+		}
+		let ident: syn::Ident = self.input.parse()?;
+		self.input.parse::<Token![=]>()?;
+		Ok(Some(ident.to_string()))
+	}
+
+	fn parse_string(&mut self) -> Result<String> {
+		Ok(self.input.parse::<LitStr>()?.value())
+	}
+
+	fn parse_bool(&mut self) -> Result<bool> {
+		Ok(self.input.parse::<LitBool>()?.value)
+	}
+
+	fn parse_u32(&mut self) -> Result<u32> {
+		self.input.parse::<LitInt>()?.base10_parse()
+	}
+
+	fn parse_expr(&mut self) -> Result<Expr> {
+		self.input.parse()
+	}
+
+	fn parse_string_array(&mut self) -> Result<Vec<String>> {
+		let content;
+		bracketed!(content in self.input);
+		let mut values = Vec::new();
+		while !content.is_empty() {
+			values.push(content.parse::<LitStr>()?.value());
+			if content.is_empty() {
+				break;
+			}
+			content.parse::<Token![,]>()?;
+		}
+		Ok(values)
+	}
+
+	fn unknown_key(&self, key: &str) -> syn::Error {
+		syn::Error::new(self.input.span(), format!("unknown attribute key `{key}`"))
+	}
+}
+
+fn assign_option<T>(slot: &mut Option<T>, key: String, value: T) -> Result<()> {
+	if slot.is_some() {
+		return Err(syn::Error::new(proc_macro2::Span::call_site(), format!("duplicate attribute key `{key}`")));
+	}
+	*slot = Some(value);
+	Ok(())
+}
+
+fn require_field<T>(value: Option<T>, name: &str) -> Result<T> {
+	value.ok_or_else(|| syn::Error::new(proc_macro2::Span::call_site(), format!("missing required attribute key `{name}`")))
+}
+

--- a/crates/puniyu_macros/src/types.rs
+++ b/crates/puniyu_macros/src/types.rs
@@ -1,4 +1,7 @@
-use syn::{Expr, LitBool, LitInt, LitStr, Result, Token, bracketed, parse::{Parse, ParseStream}};
+use syn::{
+	Expr, LitBool, LitInt, LitStr, Result, Token, bracketed,
+	parse::{Parse, ParseStream},
+};
 
 pub(crate) struct ConfigArgs {
 	pub name: Option<String>,
@@ -11,7 +14,7 @@ pub(crate) struct AdapterArgs {
 
 pub(crate) struct HookArgs {
 	pub name: Option<String>,
-	pub hook_type: Option<String>,
+	pub hook_type: Option<LitStr>,
 	pub priority: Option<u32>,
 }
 
@@ -23,13 +26,13 @@ pub(crate) struct PluginArg {
 
 pub(crate) struct TaskArgs {
 	pub name: Option<String>,
-	pub cron: String,
+	pub cron: LitStr,
 }
 
 pub(crate) struct ArgType {
 	pub name: String,
-	pub arg_type: Option<String>,
-	pub mode: Option<String>,
+	pub arg_type: Option<LitStr>,
+	pub mode: Option<LitStr>,
 	pub required: Option<bool>,
 	pub desc: Option<String>,
 }
@@ -39,7 +42,7 @@ pub(crate) struct CommandArgs {
 	pub priority: Option<u32>,
 	pub desc: Option<String>,
 	pub alias: Option<Vec<String>>,
-	pub permission: Option<String>,
+	pub permission: Option<LitStr>,
 }
 
 impl ConfigArgs {
@@ -123,7 +126,7 @@ impl Parse for HookArgs {
 			match key.as_str() {
 				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
 				"hook_type" | "type" | "r#type" => {
-					assign_option(&mut hook_type, key, parser.parse_string()?)?
+					assign_option(&mut hook_type, key, parser.parse_lit_str()?)?
 				}
 				"priority" => assign_option(&mut priority, key, parser.parse_u32()?)?,
 				_ => return Err(parser.unknown_key(&key)),
@@ -163,7 +166,7 @@ impl Parse for TaskArgs {
 		while let Some(key) = parser.next_key()? {
 			match key.as_str() {
 				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
-				"cron" => assign_option(&mut cron, key, parser.parse_string()?)?,
+				"cron" => assign_option(&mut cron, key, parser.parse_lit_str()?)?,
 				_ => return Err(parser.unknown_key(&key)),
 			}
 		}
@@ -185,22 +188,16 @@ impl Parse for ArgType {
 			match key.as_str() {
 				"name" => assign_option(&mut name, key, parser.parse_string()?)?,
 				"arg_type" | "type" | "r#type" => {
-					assign_option(&mut arg_type, key, parser.parse_string()?)?
+					assign_option(&mut arg_type, key, parser.parse_lit_str()?)?
 				}
-				"mode" => assign_option(&mut mode, key, parser.parse_string()?)?,
+				"mode" => assign_option(&mut mode, key, parser.parse_lit_str()?)?,
 				"required" => assign_option(&mut required, key, parser.parse_bool()?)?,
 				"desc" => assign_option(&mut desc, key, parser.parse_string()?)?,
 				_ => return Err(parser.unknown_key(&key)),
 			}
 		}
 
-		Ok(Self {
-			name: require_field(name, "name")?,
-			arg_type,
-			mode,
-			required,
-			desc,
-		})
+		Ok(Self { name: require_field(name, "name")?, arg_type, mode, required, desc })
 	}
 }
 
@@ -219,44 +216,54 @@ impl Parse for CommandArgs {
 				"priority" => assign_option(&mut priority, key, parser.parse_u32()?)?,
 				"desc" => assign_option(&mut desc, key, parser.parse_string()?)?,
 				"alias" => assign_option(&mut alias, key, parser.parse_string_array()?)?,
-				"permission" => assign_option(&mut permission, key, parser.parse_string()?)?,
+				"permission" => assign_option(&mut permission, key, parser.parse_lit_str()?)?,
 				_ => return Err(parser.unknown_key(&key)),
 			}
 		}
 
-		Ok(Self {
-			name: require_field(name, "name")?,
-			priority,
-			desc,
-			alias,
-			permission,
-		})
+		Ok(Self { name: require_field(name, "name")?, priority, desc, alias, permission })
 	}
 }
 
 struct KeyValueParser<'a> {
 	input: ParseStream<'a>,
+	parsed_any: bool,
 }
 
 impl<'a> KeyValueParser<'a> {
 	fn new(input: ParseStream<'a>) -> Self {
-		Self { input }
+		Self { input, parsed_any: false }
 	}
 
 	fn next_key(&mut self) -> Result<Option<String>> {
-		while self.input.peek(Token![,]) {
-			self.input.parse::<Token![,]>()?;
-		}
 		if self.input.is_empty() {
 			return Ok(None);
 		}
+		if self.parsed_any {
+			self.input.parse::<Token![,]>()?;
+			if self.input.is_empty() {
+				return Ok(None);
+			}
+		} else {
+			while self.input.peek(Token![,]) {
+				self.input.parse::<Token![,]>()?;
+			}
+			if self.input.is_empty() {
+				return Ok(None);
+			}
+		}
 		let ident: syn::Ident = self.input.parse()?;
 		self.input.parse::<Token![=]>()?;
+		self.parsed_any = true;
 		Ok(Some(ident.to_string()))
 	}
 
+	fn parse_lit_str(&mut self) -> Result<LitStr> {
+		self.input.parse()
+	}
+
 	fn parse_string(&mut self) -> Result<String> {
-		Ok(self.input.parse::<LitStr>()?.value())
+		Ok(self.parse_lit_str()?.value())
 	}
 
 	fn parse_bool(&mut self) -> Result<bool> {
@@ -292,13 +299,20 @@ impl<'a> KeyValueParser<'a> {
 
 fn assign_option<T>(slot: &mut Option<T>, key: String, value: T) -> Result<()> {
 	if slot.is_some() {
-		return Err(syn::Error::new(proc_macro2::Span::call_site(), format!("duplicate attribute key `{key}`")));
+		return Err(syn::Error::new(
+			proc_macro2::Span::call_site(),
+			format!("duplicate attribute key `{key}`"),
+		));
 	}
 	*slot = Some(value);
 	Ok(())
 }
 
 fn require_field<T>(value: Option<T>, name: &str) -> Result<T> {
-	value.ok_or_else(|| syn::Error::new(proc_macro2::Span::call_site(), format!("missing required attribute key `{name}`")))
+	value.ok_or_else(|| {
+		syn::Error::new(
+			proc_macro2::Span::call_site(),
+			format!("missing required attribute key `{name}`"),
+		)
+	})
 }
-

--- a/crates/puniyu_macros/src/types.rs
+++ b/crates/puniyu_macros/src/types.rs
@@ -75,6 +75,12 @@ impl TaskArgs {
 	}
 }
 
+impl ArgType {
+	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
+		syn::parse2(input)
+	}
+}
+
 impl CommandArgs {
 	pub fn parse_tokens(input: proc_macro2::TokenStream) -> Result<Self> {
 		syn::parse2(input)

--- a/crates/puniyu_macros/src/types.rs
+++ b/crates/puniyu_macros/src/types.rs
@@ -38,7 +38,7 @@ pub(crate) struct ArgType {
 }
 
 pub(crate) struct CommandArgs {
-	pub name: String,
+	pub name: Option<String>,
 	pub priority: Option<u32>,
 	pub desc: Option<String>,
 	pub alias: Option<Vec<String>>,
@@ -227,7 +227,7 @@ impl Parse for CommandArgs {
 			}
 		}
 
-		Ok(Self { name: require_field(name, "name")?, priority, desc, alias, permission })
+		Ok(Self { name, priority, desc, alias, permission })
 	}
 }
 

--- a/crates/puniyu_macros/tests/trybuild.rs
+++ b/crates/puniyu_macros/tests/trybuild.rs
@@ -1,0 +1,6 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass_*.rs");
+    t.compile_fail("tests/ui/fail_*.rs");
+}

--- a/crates/puniyu_macros/tests/trybuild.rs
+++ b/crates/puniyu_macros/tests/trybuild.rs
@@ -1,6 +1,6 @@
 #[test]
 fn ui() {
-    let t = trybuild::TestCases::new();
-    t.pass("tests/ui/pass_*.rs");
-    t.compile_fail("tests/ui/fail_*.rs");
+	let t = trybuild::TestCases::new();
+	t.pass("tests/ui/pass_*.rs");
+	t.compile_fail("tests/ui/fail_*.rs");
 }

--- a/crates/puniyu_macros/tests/ui/fail_arg_missing_name.rs
+++ b/crates/puniyu_macros/tests/ui/fail_arg_missing_name.rs
@@ -1,0 +1,14 @@
+use puniyu_macros::{arg, command, plugin};
+use puniyu_plugin::command::CommandAction;
+use puniyu_context::MessageContext;
+
+#[plugin]
+async fn __main() {}
+
+#[arg(desc = "消息")]
+#[command(name = "echo")]
+async fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+	CommandAction::done()
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/fail_command_bad_permission.rs
+++ b/crates/puniyu_macros/tests/ui/fail_command_bad_permission.rs
@@ -1,0 +1,10 @@
+use puniyu_macros::command;
+use puniyu_plugin::command::CommandAction;
+use puniyu_context::MessageContext;
+
+#[command(name = "echo", permission = "root")]
+async fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+    CommandAction::done()
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/fail_command_non_async.rs
+++ b/crates/puniyu_macros/tests/ui/fail_command_non_async.rs
@@ -1,0 +1,10 @@
+use puniyu_macros::command;
+use puniyu_plugin::command::CommandAction;
+use puniyu_context::MessageContext;
+
+#[command(name = "echo")]
+fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+    CommandAction::done()
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/fail_plugin_hook_bad_type.rs
+++ b/crates/puniyu_macros/tests/ui/fail_plugin_hook_bad_type.rs
@@ -1,0 +1,9 @@
+use puniyu_macros::plugin_hook;
+use puniyu_plugin::hook::HookType;
+
+#[plugin_hook(hook_type = "event.unknown")]
+async fn on_message(_event: &HookType) -> puniyu_plugin::Result {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/fail_plugin_hook_bad_type.rs
+++ b/crates/puniyu_macros/tests/ui/fail_plugin_hook_bad_type.rs
@@ -1,5 +1,8 @@
-use puniyu_macros::plugin_hook;
+use puniyu_macros::{plugin, plugin_hook};
 use puniyu_plugin::hook::HookType;
+
+#[plugin]
+async fn __main() {}
 
 #[plugin_hook(hook_type = "event.unknown")]
 async fn on_message(_event: &HookType) -> puniyu_plugin::Result {

--- a/crates/puniyu_macros/tests/ui/fail_task_bad_cron.rs
+++ b/crates/puniyu_macros/tests/ui/fail_task_bad_cron.rs
@@ -1,0 +1,8 @@
+use puniyu_macros::task;
+
+#[task(cron = "bad cron")]
+async fn health_check() -> puniyu_plugin::Result {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/fail_task_missing_comma.rs
+++ b/crates/puniyu_macros/tests/ui/fail_task_missing_comma.rs
@@ -1,0 +1,11 @@
+use puniyu_macros::{plugin, task};
+
+#[plugin]
+async fn __main() {}
+
+#[task(cron = "0 * * * * *" name = "health_check")]
+async fn health_check() -> puniyu_plugin::Result {
+	Ok(())
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_adapter_config.rs
+++ b/crates/puniyu_macros/tests/ui/pass_adapter_config.rs
@@ -1,0 +1,43 @@
+use puniyu_macros::{adapter, adapter_config};
+use puniyu_adapter::types::{adapter_info, AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
+use puniyu_adapter::{contact::ContactType, message::Message};
+use std::sync::Arc;
+
+struct Runtime {
+	adapter: AdapterInfo,
+}
+
+impl puniyu_adapter::runtime::AdapterProvider for Runtime {
+	fn adapter_info(&self) -> &AdapterInfo {
+		&self.adapter
+	}
+}
+
+#[puniyu_adapter::__private::async_trait]
+impl puniyu_adapter::runtime::SendMessage for Runtime {
+	async fn send_message(&self, _contact: &ContactType<'_>, _message: &Message) -> puniyu_adapter::Result<SendMsgType> {
+		Ok(SendMsgType {
+			message_id: "1".into(),
+			time: 0,
+		})
+	}
+}
+
+fn runtime() -> Arc<dyn puniyu_adapter::runtime::AdapterRuntime> {
+	Arc::new(Runtime {
+		adapter: adapter_info!("test", AdapterPlatform::Other, AdapterProtocol::Console),
+	})
+}
+
+#[adapter(runtime = runtime)]
+async fn __main() -> puniyu_adapter::Result {
+	Ok(())
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[adapter_config(name = "sample")]
+struct SampleConfig {
+	value: String,
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_command.rs
+++ b/crates/puniyu_macros/tests/ui/pass_command.rs
@@ -1,0 +1,15 @@
+use puniyu_macros::{command, plugin};
+use puniyu_plugin::command::CommandAction;
+use puniyu_context::MessageContext;
+
+#[plugin]
+async fn __main() {}
+
+#[command(name = "echo", desc = "echo", alias = ["say"], permission = "all")]
+#[arg(name = "message", desc = "消息")]
+#[arg(name = "count", r#type = "int", mode = "named", desc = "次数")]
+async fn echo(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+    CommandAction::done()
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_command_infer_name.rs
+++ b/crates/puniyu_macros/tests/ui/pass_command_infer_name.rs
@@ -1,0 +1,14 @@
+use puniyu_macros::{command, plugin};
+use puniyu_plugin::command::CommandAction;
+use puniyu_context::MessageContext;
+
+#[plugin]
+async fn __main() {}
+
+#[command(desc = "echo", alias = ["say"], permission = "all")]
+#[arg(name = "message", desc = "消息")]
+async fn echo_message(_ctx: &MessageContext<'_>) -> puniyu_plugin::Result<CommandAction> {
+    CommandAction::done()
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_plugin_config.rs
+++ b/crates/puniyu_macros/tests/ui/pass_plugin_config.rs
@@ -1,0 +1,12 @@
+use puniyu_macros::{plugin, plugin_config};
+
+#[plugin]
+async fn __main() {}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[plugin_config(name = "sample")]
+struct SampleConfig {
+	value: String,
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_plugin_hook.rs
+++ b/crates/puniyu_macros/tests/ui/pass_plugin_hook.rs
@@ -1,0 +1,12 @@
+use puniyu_macros::{plugin, plugin_hook};
+use puniyu_plugin::hook::HookType;
+
+#[plugin]
+async fn __main() {}
+
+#[plugin_hook(name = "on_message", hook_type = "event.message", priority = 100)]
+async fn on_message(_event: &HookType) -> puniyu_plugin::Result {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/puniyu_macros/tests/ui/pass_task.rs
+++ b/crates/puniyu_macros/tests/ui/pass_task.rs
@@ -1,0 +1,11 @@
+use puniyu_macros::{plugin, task};
+
+#[plugin]
+async fn __main() {}
+
+#[task(cron = "0 * * * * *", name = "health_check")]
+async fn health_check() -> puniyu_plugin::Result {
+    Ok(())
+}
+
+fn main() {}

--- a/justfile
+++ b/justfile
@@ -1,4 +1,8 @@
 set windows-shell := ["powershell.exe", "-c"]
 set shell := ["bash", "-cu"]
+
 test:
+    just crates/puniyu_macros/
     cargo test
+
+    


### PR DESCRIPTION
- 移除不再需要的 zyn 和 yansi 依赖包
- 使用 quote、syn、proc-macro2 替代 zyn 进行代码生成
- 重构 adapter、config、hook 宏实现以使用标准的 Rust 宏工具链
- 改进钩子类型解析逻辑并添加更详细的错误信息
- 增加对适配器服务器功能的支持
- 添加示例文件展示命令、插件钩子和任务宏的使用方法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 将宏实现迁移为原生 Rust 过程宏，统一使用 syn/quote/proc-macro2 重写生成与验证逻辑。
  * 中央化解析与错误处理，改进参数解析与路径/类型匹配工具函数。

* **测试**
  * 增加基于 trybuild 的编译时 UI 测试（通过/失败用例）。

* **其他**
  * 新增并导出 adapter 的 context 模块以暴露底层上下文类型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->