### PR TITLE
chore: 添加适配器API模块并重构相关组件

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "puniyu_adapter_api"
+version = "0.8.9"
+dependencies = [
+ "async-trait",
+ "puniyu_adapter_types",
+ "puniyu_contact",
+ "puniyu_error",
+ "puniyu_message",
+]
+
+[[package]]
 name = "puniyu_adapter_core"
 version = "0.8.9"
 dependencies = [
@@ -1764,12 +1775,11 @@ dependencies = [
  "const-str",
  "log",
  "puniyu_account",
+ "puniyu_adapter_api",
  "puniyu_adapter_types",
  "puniyu_config",
- "puniyu_contact",
  "puniyu_error",
  "puniyu_message",
- "puniyu_runtime",
  "puniyu_semver",
  "puniyu_server",
  "puniyu_version",
@@ -1797,6 +1807,7 @@ dependencies = [
  "async-trait",
  "inventory",
  "puniyu_account",
+ "puniyu_adapter_api",
  "puniyu_bot",
  "puniyu_command",
  "puniyu_common",
@@ -1825,6 +1836,7 @@ version = "0.8.8"
 dependencies = [
  "log",
  "puniyu_account",
+ "puniyu_adapter_api",
  "puniyu_adapter_types",
  "puniyu_contact",
  "puniyu_error",
@@ -1913,6 +1925,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "puniyu_account",
+ "puniyu_adapter_api",
+ "puniyu_adapter_core",
  "puniyu_adapter_types",
  "puniyu_bot",
  "puniyu_command_types",
@@ -1952,6 +1966,7 @@ dependencies = [
  "puniyu_message",
  "puniyu_path",
  "puniyu_plugin_core",
+ "puniyu_runtime",
  "puniyu_segment",
  "puniyu_semver",
  "puniyu_sender",
@@ -1999,6 +2014,8 @@ dependencies = [
  "bytes",
  "derive_more",
  "puniyu_account",
+ "puniyu_adapter_api",
+ "puniyu_adapter_core",
  "puniyu_adapter_types",
  "puniyu_bot",
  "puniyu_contact",
@@ -2083,8 +2100,8 @@ name = "puniyu_runtime"
 version = "0.8.8"
 dependencies = [
  "actix-web",
- "async-trait",
  "puniyu_account",
+ "puniyu_adapter_api",
  "puniyu_adapter_types",
  "puniyu_contact",
  "puniyu_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
 name = "puniyu_adapter_api"
 version = "0.8.9"
 dependencies = [
+ "anyhow",
  "async-trait",
  "puniyu_adapter_types",
  "puniyu_contact",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ version = "0.8.9"
 dependencies = [
  "anyhow",
  "async-trait",
+ "puniyu_account",
  "puniyu_adapter_types",
  "puniyu_contact",
  "puniyu_error",
@@ -1809,6 +1810,8 @@ dependencies = [
  "inventory",
  "puniyu_account",
  "puniyu_adapter_api",
+ "puniyu_adapter_core",
+ "puniyu_adapter_types",
  "puniyu_bot",
  "puniyu_command",
  "puniyu_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ puniyu_config = { version = "0.8.8", path = "./crates/puniyu_config" }
 
 puniyu_adapter_core = { version = "0.8.9", path = "./crates/puniyu_adapter_core" }
 puniyu_adapter_types = { version = "0.8.8", path = "./crates/puniyu_adapter_types" }
+puniyu_adapter_api = { version = "0.8.9", path = "./crates/puniyu_adapter_api" }
 puniyu_runtime = { version = "0.8.8", path = "./crates/puniyu_runtime" }
 
 puniyu_bot = { version = "0.8.8", path = "./crates/puniyu_bot" }

--- a/crates/puniyu_adapter_api/Cargo.toml
+++ b/crates/puniyu_adapter_api/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+anyhow = "1.0.102"
 async-trait.workspace = true
 puniyu_adapter_types.workspace = true
 puniyu_contact.workspace = true

--- a/crates/puniyu_adapter_api/Cargo.toml
+++ b/crates/puniyu_adapter_api/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "puniyu_adapter_api"
+version = "0.8.9"
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait.workspace = true
+puniyu_adapter_types.workspace = true
+puniyu_contact.workspace = true
+puniyu_error.workspace = true
+puniyu_message.workspace = true

--- a/crates/puniyu_adapter_api/Cargo.toml
+++ b/crates/puniyu_adapter_api/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.102"
 async-trait.workspace = true
+puniyu_account.workspace = true
 puniyu_adapter_types.workspace = true
 puniyu_contact.workspace = true
 puniyu_error.workspace = true

--- a/crates/puniyu_adapter_api/src/lib.rs
+++ b/crates/puniyu_adapter_api/src/lib.rs
@@ -8,7 +8,8 @@
 //! - [`OneBotAdapterApi`]：OneBot 协议 API trait
 
 
-use puniyu_adapter_types::SendMsgType;
+use puniyu_account::AccountInfo;
+use puniyu_adapter_types::{AdapterInfo, SendMsgType};
 use puniyu_contact::ContactType;
 use puniyu_error::Result;
 use puniyu_message::Message;
@@ -19,12 +20,20 @@ pub use onebot::OneBotAdapterApi;
 
 #[async_trait]
 pub trait AdapterApi: Send + Sync {
+    /// 发送消息
     async fn send_message(
         &self,
         contact: &ContactType<'_>,
         message: &Message,
     ) -> Result<SendMsgType>;
 
+    /// 获取适配器信息
+    fn adapter_info(&self) -> AdapterInfo;
+
+    /// 获取账户信息
+    fn account_info(&self) -> AccountInfo;
+
+    /// 转换为OneBot适配器
     fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> { None }
 }
 

--- a/crates/puniyu_adapter_api/src/lib.rs
+++ b/crates/puniyu_adapter_api/src/lib.rs
@@ -1,0 +1,31 @@
+//! # puniyu_adapter_api
+//!
+//! 统一的适配器 API trait 定义。
+//!
+//! ## 提供内容
+//!
+//! - [`AdapterApi`]：适配器基础 API trait
+//! - [`OneBotAdapterApi`]：OneBot 协议 API trait
+
+
+use puniyu_adapter_types::SendMsgType;
+use puniyu_contact::ContactType;
+use puniyu_error::Result;
+use puniyu_message::Message;
+use async_trait::async_trait;
+
+mod onebot;
+pub use onebot::OneBotAdapterApi;
+
+
+
+#[async_trait]
+pub trait AdapterApi: Send + Sync { 
+    async fn send_message(
+        &self,
+        contact: &ContactType<'_>,
+        message: &Message,
+    ) -> Result<SendMsgType>;
+
+}
+

--- a/crates/puniyu_adapter_api/src/lib.rs
+++ b/crates/puniyu_adapter_api/src/lib.rs
@@ -17,15 +17,14 @@ use async_trait::async_trait;
 mod onebot;
 pub use onebot::OneBotAdapterApi;
 
-
-
 #[async_trait]
-pub trait AdapterApi: Send + Sync { 
+pub trait AdapterApi: Send + Sync {
     async fn send_message(
         &self,
         contact: &ContactType<'_>,
         message: &Message,
     ) -> Result<SendMsgType>;
 
+    fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> { None }
 }
 

--- a/crates/puniyu_adapter_api/src/onebot.rs
+++ b/crates/puniyu_adapter_api/src/onebot.rs
@@ -1,45 +1,43 @@
 use async_trait::async_trait;
 use puniyu_adapter_types::SendMsgType;
 use puniyu_contact::{Contact, ContactType};
-use puniyu_message::Message;
 use puniyu_error::Result;
+use puniyu_message::Message;
 
 use crate::AdapterApi;
+use anyhow::anyhow;
 
 #[async_trait]
 pub trait OneBotAdapterApi: Send + Sync {
+    /// 发送私聊消息
+	async fn send_private_msg(&self, user_id: u64, message: &Message) -> Result<SendMsgType>;
 
-    async fn send_private_msg(
-        &self,
-        user_id: u64,
-        message: &Message,
-    ) -> Result<SendMsgType>;
-
-    async fn send_group_msg(
-        &self,
-        group_id: u64,
-        message: &Message,
-    ) -> Result<SendMsgType>;
+    /// 发送群消息
+	async fn send_group_msg(&self, group_id: u64, message: &Message) -> Result<SendMsgType>;
 }
 
 #[async_trait]
 impl<T: OneBotAdapterApi> AdapterApi for T {
-    #[allow(clippy::unwrap_used)]
-    async fn send_message(
-        &self,
-        contact: &ContactType<'_>,
-        message: &Message,
-    ) -> Result<SendMsgType> {
-        match contact {
-            ContactType::Friend(contact) => {
-                self.send_private_msg(contact.peer().parse::<u64>()?, message).await
-            }
-            ContactType::Group(contact) => {
-                self.send_group_msg(contact.peer().parse::<u64>()?, message).await
-            }
-            _ => unimplemented!("不支持的 ContactType: {:?}", contact),
-        }
-    }
+	async fn send_message(
+		&self,
+		contact: &ContactType<'_>,
+		message: &Message,
+	) -> Result<SendMsgType> {
+		match contact {
+			ContactType::Friend(contact) => {
+				self.send_private_msg(contact.peer().parse::<u64>()?, message).await
+			}
+			ContactType::Group(contact) => {
+				self.send_group_msg(contact.peer().parse::<u64>()?, message).await
+			}
+			ContactType::GroupTemp(concat) => {
+				self.send_private_msg(concat.peer().parse::<u64>()?, message).await
+			}
+			_ => Err(anyhow!("unsupported contact type: {:?}", contact).into()),
+		}
+	}
 
-    fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> { Some(self) }
+	fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> {
+		Some(self)
+	}
 }

--- a/crates/puniyu_adapter_api/src/onebot.rs
+++ b/crates/puniyu_adapter_api/src/onebot.rs
@@ -1,0 +1,43 @@
+use async_trait::async_trait;
+use puniyu_adapter_types::SendMsgType;
+use puniyu_contact::{Contact, ContactType};
+use puniyu_message::Message;
+use puniyu_error::Result;
+
+use crate::AdapterApi;
+
+#[async_trait]
+pub trait OneBotAdapterApi: Send + Sync {
+
+    async fn send_private_msg(
+        &self,
+        user_id: u64,
+        message: &Message,
+    ) -> Result<SendMsgType>;
+
+    async fn send_group_msg(
+        &self,
+        group_id: u64,
+        message: &Message,
+    ) -> Result<SendMsgType>;
+}
+
+#[async_trait]
+impl<T: OneBotAdapterApi> AdapterApi for T {
+    #[allow(clippy::unwrap_used)]
+    async fn send_message(
+        &self,
+        contact: &ContactType<'_>,
+        message: &Message,
+    ) -> Result<SendMsgType> {
+        match contact {
+            ContactType::Friend(contact) => {
+                self.send_private_msg(contact.peer().parse::<u64>()?, message).await
+            }
+            ContactType::Group(contact) => {
+                self.send_group_msg(contact.peer().parse::<u64>()?, message).await
+            }
+            _ => panic!("不支持的 ContactType"),
+        }
+    }
+}

--- a/crates/puniyu_adapter_api/src/onebot.rs
+++ b/crates/puniyu_adapter_api/src/onebot.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use puniyu_adapter_types::SendMsgType;
+use puniyu_account::AccountInfo;
+use puniyu_adapter_types::{AdapterInfo, SendMsgType};
 use puniyu_contact::{Contact, ContactType};
 use puniyu_error::Result;
 use puniyu_message::Message;
@@ -14,6 +15,12 @@ pub trait OneBotAdapterApi: Send + Sync {
 
     /// 发送群消息
 	async fn send_group_msg(&self, group_id: u64, message: &Message) -> Result<SendMsgType>;
+
+    // 适配器信息
+	fn adapter_info(&self) -> AdapterInfo;
+
+    // 账号信息
+	fn account_info(&self) -> AccountInfo;
 }
 
 #[async_trait]
@@ -35,6 +42,14 @@ impl<T: OneBotAdapterApi> AdapterApi for T {
 			}
 			_ => Err(anyhow!("unsupported contact type: {:?}", contact).into()),
 		}
+	}
+
+	fn adapter_info(&self) -> AdapterInfo {
+        self.adapter_info()
+	}
+
+	fn account_info(&self) -> AccountInfo {
+		self.account_info()
 	}
 
 	fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> {

--- a/crates/puniyu_adapter_api/src/onebot.rs
+++ b/crates/puniyu_adapter_api/src/onebot.rs
@@ -37,7 +37,9 @@ impl<T: OneBotAdapterApi> AdapterApi for T {
             ContactType::Group(contact) => {
                 self.send_group_msg(contact.peer().parse::<u64>()?, message).await
             }
-            _ => panic!("不支持的 ContactType"),
+            _ => unimplemented!("不支持的 ContactType: {:?}", contact),
         }
     }
+
+    fn as_onebot(&self) -> Option<&dyn OneBotAdapterApi> { Some(self) }
 }

--- a/crates/puniyu_adapter_core/Cargo.toml
+++ b/crates/puniyu_adapter_core/Cargo.toml
@@ -20,21 +20,14 @@ async-trait.workspace = true
 puniyu_semver.workspace = true
 const-str.workspace = true
 puniyu_adapter_types.workspace = true
-puniyu_runtime.workspace = true
+puniyu_adapter_api.workspace = true
 puniyu_config.workspace = true
 puniyu_error.workspace = true
 puniyu_server.workspace = true
 puniyu_version.workspace = true
 puniyu_account.workspace = true
+puniyu_message.workspace = true
 
 [features]
 default = []
 registry = ["puniyu_error/registry"]
-
-[dev-dependencies]
-async-trait.workspace = true
-
-puniyu_runtime.workspace = true
-puniyu_adapter_types.workspace = true
-puniyu_contact.workspace = true
-puniyu_message.workspace = true

--- a/crates/puniyu_adapter_core/src/lib.rs
+++ b/crates/puniyu_adapter_core/src/lib.rs
@@ -11,47 +11,47 @@ mod types;
 pub use types::*;
 
 use puniyu_account::AccountInfo;
+use puniyu_adapter_types::AdapterInfo;
+use puniyu_adapter_api::AdapterApi;
 use puniyu_config::Config;
-use puniyu_runtime::AdapterRuntime;
+use puniyu_error::Result;
 use std::sync::Arc;
+
+pub use puniyu_adapter_api::OneBotAdapterApi;
 
 #[async_trait::async_trait]
 pub trait Adapter: Send + Sync + 'static {
-	/// 返回该适配器下所有需要注册的账号列表
-	fn accounts(&self) -> Vec<AccountInfo> { Vec::new() }
+    fn accounts(&self) -> Vec<AccountInfo> { Vec::new() }
 
-	/// 获取适配器运行时。
-	fn runtime(&self) -> Arc<dyn AdapterRuntime>;
+    fn info(&self) -> AdapterInfo;
 
-	fn core_version(&self) -> Version {
-		puniyu_version::VERSION
-	}
+    fn api(&self) -> Arc<dyn AdapterApi>;
 
-	/// 获取配置列表。
-	fn config(&self) -> Vec<Arc<dyn Config>> {
-		Vec::new()
-	}
+    fn core_version(&self) -> Version {
+        puniyu_version::VERSION
+    }
 
-	/// 获取服务器扩展。
-	fn server(&self) -> Option<puniyu_server::ServerFunction> {
-		None
-	}
+    fn config(&self) -> Vec<Arc<dyn Config>> {
+        Vec::new()
+    }
 
-	/// 适配器加载时回调。
-	async fn on_load(&self) -> puniyu_error::Result {
-		log::info!("Adapter: loaded");
-		Ok(())
-	}
+    fn server(&self) -> Option<puniyu_server::ServerFunction> {
+        None
+    }
 
-	/// 适配器卸载时回调。
-	async fn on_unload(&self) -> puniyu_error::Result {
-		log::info!("Adapter: unloaded");
-		Ok(())
-	}
+    async fn on_load(&self) -> Result {
+        log::info!("Adapter: loaded");
+        Ok(())
+    }
+
+    async fn on_unload(&self) -> Result {
+        log::info!("Adapter: unloaded");
+        Ok(())
+    }
 }
 
 impl PartialEq for dyn Adapter {
-	fn eq(&self, other: &Self) -> bool {
-		self.runtime().adapter_info() == other.runtime().adapter_info()
-	}
+    fn eq(&self, other: &Self) -> bool {
+        self.info() == other.info()
+    }
 }

--- a/crates/puniyu_adapter_core/src/lib.rs
+++ b/crates/puniyu_adapter_core/src/lib.rs
@@ -10,22 +10,13 @@ mod types;
 #[doc(inline)]
 pub use types::*;
 
-use puniyu_account::AccountInfo;
-use puniyu_adapter_types::AdapterInfo;
-use puniyu_adapter_api::AdapterApi;
 use puniyu_config::Config;
 use puniyu_error::Result;
 use std::sync::Arc;
 
-pub use puniyu_adapter_api::OneBotAdapterApi;
-
 #[async_trait::async_trait]
 pub trait Adapter: Send + Sync + 'static {
-    fn accounts(&self) -> Vec<AccountInfo> { Vec::new() }
-
-    fn info(&self) -> AdapterInfo;
-
-    fn api(&self) -> Arc<dyn AdapterApi>;
+    fn name(&self) -> &str;
 
     fn core_version(&self) -> Version {
         puniyu_version::VERSION
@@ -47,11 +38,5 @@ pub trait Adapter: Send + Sync + 'static {
     async fn on_unload(&self) -> Result {
         log::info!("Adapter: unloaded");
         Ok(())
-    }
-}
-
-impl PartialEq for dyn Adapter {
-    fn eq(&self, other: &Self) -> bool {
-        self.info() == other.info()
     }
 }

--- a/crates/puniyu_adapter_core/src/registry.rs
+++ b/crates/puniyu_adapter_core/src/registry.rs
@@ -44,10 +44,10 @@ impl<'a> AdapterRegistry {
 	pub fn unregister_with_adapter_name(name: &str) -> Result<(), Error> {
 		let raw = STORE.raw();
 		let mut map = raw.write().expect("Failed to acquire lock");
-		if !map.values().any(|v| v.info().name == name) {
+		if !map.values().any(|v| v.name() == name) {
 			return Err(Error::NotFound("Adapter".to_string()));
 		}
-		map.retain(|_, v| v.info().name != name);
+		map.retain(|_, v| v.name() != name);
 		Ok(())
 	}
 
@@ -74,7 +74,7 @@ impl<'a> AdapterRegistry {
 	pub fn get_with_adapter_name(name: &str) -> Vec<Arc<dyn Adapter>> {
 		let raw = STORE.raw();
 		let map = raw.read().expect("Failed to acquire lock");
-		map.values().filter(|v| v.info().name == name).cloned().collect()
+		map.values().filter(|v| v.name() == name).cloned().collect()
 	}
 
 	/// 获取所有已注册适配器。

--- a/crates/puniyu_adapter_core/src/registry.rs
+++ b/crates/puniyu_adapter_core/src/registry.rs
@@ -44,10 +44,10 @@ impl<'a> AdapterRegistry {
 	pub fn unregister_with_adapter_name(name: &str) -> Result<(), Error> {
 		let raw = STORE.raw();
 		let mut map = raw.write().expect("Failed to acquire lock");
-		if !map.values().any(|v| v.runtime().adapter_info().name == name) {
+		if !map.values().any(|v| v.info().name == name) {
 			return Err(Error::NotFound("Adapter".to_string()));
 		}
-		map.retain(|_, v| v.runtime().adapter_info().name != name);
+		map.retain(|_, v| v.info().name != name);
 		Ok(())
 	}
 
@@ -74,7 +74,7 @@ impl<'a> AdapterRegistry {
 	pub fn get_with_adapter_name(name: &str) -> Vec<Arc<dyn Adapter>> {
 		let raw = STORE.raw();
 		let map = raw.read().expect("Failed to acquire lock");
-		map.values().filter(|v| v.runtime().adapter_info().name == name).cloned().collect()
+		map.values().filter(|v| v.info().name == name).cloned().collect()
 	}
 
 	/// 获取所有已注册适配器。

--- a/crates/puniyu_adapter_core/src/registry/store.rs
+++ b/crates/puniyu_adapter_core/src/registry/store.rs
@@ -22,8 +22,8 @@ impl AdapterStore {
 	/// 插入适配器并返回内部索引。
 	pub fn insert(&self, adapter: Arc<dyn Adapter>) -> Result<u64, Error> {
 		let mut map = self.0.write().expect("Failed to acquire lock");
-		let adapter_name = adapter.runtime().adapter_info().name.clone();
-		if map.values().any(|v| v.runtime().adapter_info().name == adapter_name) {
+		let adapter_name = adapter.info().name.clone();
+		if map.values().any(|v| v.info().name == adapter_name) {
 			return Err(Error::Exists("Adapter".to_string()));
 		}
 		let index = ADAPTER_INDEX.fetch_add(1, Ordering::SeqCst);

--- a/crates/puniyu_adapter_core/src/registry/store.rs
+++ b/crates/puniyu_adapter_core/src/registry/store.rs
@@ -22,8 +22,8 @@ impl AdapterStore {
 	/// 插入适配器并返回内部索引。
 	pub fn insert(&self, adapter: Arc<dyn Adapter>) -> Result<u64, Error> {
 		let mut map = self.0.write().expect("Failed to acquire lock");
-		let adapter_name = adapter.info().name.clone();
-		if map.values().any(|v| v.info().name == adapter_name) {
+		let adapter_name = adapter.name().to_string();
+		if map.values().any(|v| v.name() == adapter_name) {
 			return Err(Error::Exists("Adapter".to_string()));
 		}
 		let index = ADAPTER_INDEX.fetch_add(1, Ordering::SeqCst);

--- a/crates/puniyu_adapter_core/tests/registry.rs
+++ b/crates/puniyu_adapter_core/tests/registry.rs
@@ -3,13 +3,16 @@
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use async_trait::async_trait;
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_adapter_core::{Adapter, AdapterRegistry};
 use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-struct TestOneBotApi;
+#[allow(dead_code)]
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -28,17 +31,20 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
+    fn adapter_info(&self) -> AdapterInfo {
+        self.adapter_info.clone()
+    }
+
+    fn account_info(&self) -> puniyu_account::AccountInfo {
+        unimplemented!("not used in registry tests")
     }
 }
 
+#[allow(dead_code)]
 struct TestAdapter {
+    name: String,
     info: AdapterInfo,
-    api: Arc<TestOneBotApi>,
 }
 
 impl TestAdapter {
@@ -48,27 +54,15 @@ impl TestAdapter {
             .platform(AdapterPlatform::QQ)
             .protocol(AdapterProtocol::Console)
             .build();
-        Self { info, api: Arc::new(TestOneBotApi) }
-    }
-}
-
-impl Clone for TestAdapter {
-    fn clone(&self) -> Self {
-        Self {
-            info: self.info.clone(),
-            api: self.api.clone(),
-        }
+        let name = info.name.clone();
+        Self { name, info }
     }
 }
 
 #[async_trait]
 impl Adapter for TestAdapter {
-    fn info(&self) -> AdapterInfo {
-        self.info.clone()
-    }
-
-    fn api(&self) -> Arc<dyn AdapterApi> {
-        self.api.clone() as Arc<dyn AdapterApi>
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 
@@ -89,7 +83,7 @@ fn register_returns_index_and_makes_adapter_queryable() {
     let index = AdapterRegistry::register(adapter).expect("failed to register adapter");
 
     let by_index = AdapterRegistry::get_with_index(index).expect("adapter should exist by index");
-    assert_eq!(by_index.info().name, "console");
+    assert_eq!(by_index.name(), "console");
 
     let by_name = AdapterRegistry::get_with_adapter_name("console");
     assert_eq!(by_name.len(), 1);

--- a/crates/puniyu_adapter_core/tests/registry.rs
+++ b/crates/puniyu_adapter_core/tests/registry.rs
@@ -2,96 +2,114 @@
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use async_trait::async_trait;
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
 use puniyu_adapter_core::{Adapter, AdapterRegistry};
-use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
-};
-use puniyu_contact::ContactType;
-use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, AdapterRuntime, SendMessage};
+use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-#[derive(Debug)]
-struct TestRuntime {
-	info: AdapterInfo,
+struct TestOneBotApi;
+
+#[async_trait]
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &puniyu_message::Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &puniyu_message::Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
-impl AdapterProvider for TestRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.info
-	}
-}
-
-#[async_trait::async_trait]
-impl SendMessage for TestRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
 }
 
 struct TestAdapter {
-	runtime: Arc<TestRuntime>,
+    info: AdapterInfo,
+    api: Arc<dyn AdapterApi>,
 }
 
 impl TestAdapter {
-	fn new() -> Self {
-		Self {
-			runtime: Arc::new(TestRuntime {
-				info: adapter_info!("console", AdapterPlatform::QQ, AdapterProtocol::Console),
-			}),
-		}
-	}
+    fn new() -> Self {
+        let info = AdapterInfo::builder()
+            .name("console")
+            .platform(AdapterPlatform::QQ)
+            .protocol(AdapterProtocol::Console)
+            .build();
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        Self { info, api }
+    }
 }
 
-#[async_trait::async_trait]
+impl Clone for TestAdapter {
+    fn clone(&self) -> Self {
+        Self {
+            info: self.info.clone(),
+            api: self.api.clone(),
+        }
+    }
+}
+
+#[async_trait]
 impl Adapter for TestAdapter {
-	fn runtime(&self) -> Arc<dyn AdapterRuntime> {
-		self.runtime.clone()
-	}
+    fn info(&self) -> AdapterInfo {
+        self.info.clone()
+    }
+
+    fn api(&self) -> Arc<dyn AdapterApi> {
+        self.api.clone()
+    }
 }
 
 fn test_guard() -> MutexGuard<'static, ()> {
-	TEST_LOCK.lock().expect("failed to acquire adapter registry test lock")
+    TEST_LOCK.lock().expect("failed to acquire adapter registry test lock")
 }
 
 fn cleanup() {
-	let _ = AdapterRegistry::unregister_with_adapter_name("console");
+    let _ = AdapterRegistry::unregister_with_adapter_name("console");
 }
 
 #[test]
 fn register_returns_index_and_makes_adapter_queryable() {
-	let _guard = test_guard();
-	cleanup();
+    let _guard = test_guard();
+    cleanup();
 
-	let adapter: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
-	let index = AdapterRegistry::register(adapter).expect("failed to register adapter");
+    let adapter: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
+    let index = AdapterRegistry::register(adapter).expect("failed to register adapter");
 
-	let by_index = AdapterRegistry::get_with_index(index).expect("adapter should exist by index");
-	assert_eq!(by_index.runtime().adapter_info().name, "console");
+    let by_index = AdapterRegistry::get_with_index(index).expect("adapter should exist by index");
+    assert_eq!(by_index.info().name, "console");
 
-	let by_name = AdapterRegistry::get_with_adapter_name("console");
-	assert_eq!(by_name.len(), 1);
+    let by_name = AdapterRegistry::get_with_adapter_name("console");
+    assert_eq!(by_name.len(), 1);
 
-	cleanup();
+    cleanup();
 }
 
 #[test]
 fn duplicate_registration_returns_exists_error() {
-	let _guard = test_guard();
-	cleanup();
+    let _guard = test_guard();
+    cleanup();
 
-	let first: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
-	let second: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
+    let first: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
+    let second: Arc<dyn Adapter> = Arc::new(TestAdapter::new());
 
-	AdapterRegistry::register(first).expect("first register should succeed");
-	let err = AdapterRegistry::register(second).expect_err("duplicate register should fail");
+    AdapterRegistry::register(first).expect("first register should succeed");
+    let err = AdapterRegistry::register(second).expect_err("duplicate register should fail");
 
-	assert!(err.to_string().contains("exists"));
+    assert!(err.to_string().contains("exists"));
 
-	cleanup();
+    cleanup();
 }

--- a/crates/puniyu_adapter_core/tests/registry.rs
+++ b/crates/puniyu_adapter_core/tests/registry.rs
@@ -38,7 +38,7 @@ impl Clone for TestOneBotApi {
 
 struct TestAdapter {
     info: AdapterInfo,
-    api: Arc<dyn AdapterApi>,
+    api: Arc<TestOneBotApi>,
 }
 
 impl TestAdapter {
@@ -48,8 +48,7 @@ impl TestAdapter {
             .platform(AdapterPlatform::QQ)
             .protocol(AdapterProtocol::Console)
             .build();
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        Self { info, api }
+        Self { info, api: Arc::new(TestOneBotApi) }
     }
 }
 
@@ -69,7 +68,7 @@ impl Adapter for TestAdapter {
     }
 
     fn api(&self) -> Arc<dyn AdapterApi> {
-        self.api.clone()
+        self.api.clone() as Arc<dyn AdapterApi>
     }
 }
 

--- a/crates/puniyu_api/Cargo.toml
+++ b/crates/puniyu_api/Cargo.toml
@@ -33,6 +33,8 @@ puniyu_element.workspace = true
 puniyu_segment.workspace = true
 puniyu_message.workspace = true
 puniyu_adapter_api.workspace = true
+puniyu_adapter_core.workspace = true
+puniyu_adapter_types.workspace = true
 puniyu_runtime.workspace = true
 puniyu_task.workspace = true
 

--- a/crates/puniyu_api/Cargo.toml
+++ b/crates/puniyu_api/Cargo.toml
@@ -32,6 +32,7 @@ puniyu_contact.workspace = true
 puniyu_element.workspace = true
 puniyu_segment.workspace = true
 puniyu_message.workspace = true
+puniyu_adapter_api.workspace = true
 puniyu_runtime.workspace = true
 puniyu_task.workspace = true
 

--- a/crates/puniyu_api/src/adapter.rs
+++ b/crates/puniyu_api/src/adapter.rs
@@ -1,0 +1,3 @@
+pub use puniyu_adapter_api::*;
+pub use puniyu_adapter_types::*;
+pub use puniyu_adapter_core::*;

--- a/crates/puniyu_api/src/lib.rs
+++ b/crates/puniyu_api/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod adapter;
 pub mod bot;
 pub mod command;
 pub mod config;
@@ -8,6 +9,7 @@ pub mod element;
 pub mod event;
 pub mod message;
 pub mod path;
+pub mod plugin;
 pub mod result;
 pub mod runtime;
 pub mod segment;
@@ -16,17 +18,16 @@ pub mod sender;
 pub mod server;
 pub mod task;
 
+pub use async_trait;
 pub use inventory;
+pub use puniyu_common::app::{app_name, app_version};
 pub use tokio;
 pub use toml;
-pub use async_trait;
-pub use puniyu_common::app::{app_name, app_version};
 
 #[macro_export]
 macro_rules! pkg_name {
 	() => {{ env!("CARGO_PKG_NAME") }};
 }
-
 
 #[macro_export]
 macro_rules! pkg_version {

--- a/crates/puniyu_api/src/plugin.rs
+++ b/crates/puniyu_api/src/plugin.rs
@@ -1,0 +1,1 @@
+pub use puniyu_plugin_core::*;

--- a/crates/puniyu_api/src/runtime.rs
+++ b/crates/puniyu_api/src/runtime.rs
@@ -1,2 +1,2 @@
 pub use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
-pub use puniyu_runtime::AdapterRuntime;
+pub use puniyu_runtime::{AdapterRuntime, ServerRuntime};

--- a/crates/puniyu_api/src/runtime.rs
+++ b/crates/puniyu_api/src/runtime.rs
@@ -1,2 +1,1 @@
-pub use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
-pub use puniyu_runtime::{AdapterRuntime, ServerRuntime};
+pub use puniyu_runtime::{AdapterRuntime, BotRuntime, ServerRuntime};

--- a/crates/puniyu_api/src/runtime.rs
+++ b/crates/puniyu_api/src/runtime.rs
@@ -1,1 +1,2 @@
-pub use puniyu_runtime::*;
+pub use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+pub use puniyu_runtime::AdapterRuntime;

--- a/crates/puniyu_bot/Cargo.toml
+++ b/crates/puniyu_bot/Cargo.toml
@@ -17,8 +17,9 @@ workspace = true
 log.workspace = true
 puniyu_logger.workspace = true
 puniyu_account.workspace = true
-puniyu_runtime.workspace = true
 puniyu_adapter_types.workspace = true
+puniyu_adapter_api.workspace = true
 puniyu_contact.workspace = true
 puniyu_message.workspace = true
 puniyu_error = { workspace = true, features = ["registry"] }
+puniyu_runtime.workspace = true

--- a/crates/puniyu_bot/src/lib.rs
+++ b/crates/puniyu_bot/src/lib.rs
@@ -24,20 +24,25 @@ use puniyu_adapter_api::AdapterApi;
 use puniyu_contact::{Contact, ContactType};
 use puniyu_logger::owo_colors::OwoColorize;
 use puniyu_message::Message;
-pub use puniyu_runtime::AdapterRuntime;
+pub use puniyu_runtime::{AdapterRuntime, BotRuntime};
 
 #[derive(Clone)]
 pub struct Bot {
-    runtime: AdapterRuntime,
-    account: AccountInfo,
+    runtime: BotRuntime,
+    uin: String,
 }
 
 impl Bot {
-    pub fn new(runtime: AdapterRuntime, account: AccountInfo) -> Self {
-        Self { runtime, account }
+    pub fn new(runtime: BotRuntime) -> Self {
+        let uin = runtime.account_info().uin.clone();
+        Self { runtime, uin }
     }
 
-    pub fn runtime(&self) -> &AdapterRuntime {
+    pub fn self_id(&self) -> &str {
+        &self.uin
+    }
+
+    pub fn runtime(&self) -> &BotRuntime {
         &self.runtime
     }
 
@@ -45,12 +50,12 @@ impl Bot {
         self.runtime.api()
     }
 
-    pub fn adapter_info(&self) -> &AdapterInfo {
-        self.runtime.info()
+    pub fn adapter_info(&self) -> AdapterInfo {
+        self.runtime.adapter_info()
     }
 
-    pub fn account_info(&self) -> &AccountInfo {
-        &self.account
+    pub fn account_info(&self) -> AccountInfo {
+        self.runtime.account_info()
     }
 
     pub async fn send_message(

--- a/crates/puniyu_bot/src/lib.rs
+++ b/crates/puniyu_bot/src/lib.rs
@@ -24,7 +24,7 @@ use puniyu_adapter_api::AdapterApi;
 use puniyu_contact::{Contact, ContactType};
 use puniyu_logger::owo_colors::OwoColorize;
 use puniyu_message::Message;
-pub use puniyu_runtime::{AdapterRuntime};
+pub use puniyu_runtime::AdapterRuntime;
 
 #[derive(Clone)]
 pub struct Bot {

--- a/crates/puniyu_bot/src/lib.rs
+++ b/crates/puniyu_bot/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## 特性
 //!
-//! - 提供 `Bot` trait
+//! - 提供 `Bot` 结构体
 //! - 提供 `BotRegistry` 与 `BotId`
 //! - 提供便捷函数 `get_bot`、`get_bot_count` 与 `get_all_bot`
 //! - 提供宏 `register_bot!` 与 `unregister_bot!`
@@ -20,67 +20,66 @@ pub use types::*;
 
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::AdapterInfo;
+use puniyu_adapter_api::AdapterApi;
 use puniyu_contact::{Contact, ContactType};
 use puniyu_logger::owo_colors::OwoColorize;
 use puniyu_message::Message;
-pub use puniyu_runtime::{AdapterRuntime, Runtime};
-use std::sync::Arc;
+pub use puniyu_runtime::{AdapterRuntime};
 
 #[derive(Clone)]
 pub struct Bot {
-	adapter: Arc<dyn AdapterRuntime>,
-	account: AccountInfo,
+    runtime: AdapterRuntime,
+    account: AccountInfo,
 }
 
 impl Bot {
-	pub fn new(adapter: Arc<dyn AdapterRuntime>, account: AccountInfo) -> Self {
-		Self { adapter, account }
-	}
+    pub fn new(runtime: AdapterRuntime, account: AccountInfo) -> Self {
+        Self { runtime, account }
+    }
 
-	/// 获取适配器 Runtime
-	pub fn runtime<T: Runtime>(&self) -> Option<&T> {
-		let runtime: &dyn Runtime = self.adapter.as_ref();
-		runtime.downcast_ref()
-	}
+    pub fn runtime(&self) -> &AdapterRuntime {
+        &self.runtime
+    }
 
-	/// 返回适配器信息。
-	pub fn adapter_info(&self) -> &AdapterInfo {
-		self.adapter.adapter_info()
-	}
+    pub fn api(&self) -> &dyn AdapterApi {
+        self.runtime.api()
+    }
 
-	/// 返回账户信息。
-	pub fn account_info(&self) -> &AccountInfo {
-		&self.account
-	}
+    pub fn adapter_info(&self) -> &AdapterInfo {
+        self.runtime.info()
+    }
 
-	/// 发送消息。
-	pub async fn send_message(
-		&self,
-		contact: &ContactType<'_>,
-		message: &Message,
-	) -> puniyu_error::Result<puniyu_adapter_types::SendMsgType> {
-		let (msg_type, user_id) = match contact {
-			ContactType::Friend(friend) => ("PrivateMessage", &friend.peer()),
-			ContactType::Group(group) => ("GroupMssage", &group.peer()),
-			ContactType::GroupTemp(group) => ("Group TempMessage", &group.peer()),
-			ContactType::Guild(guild) => ("GuildMessage", &guild.peer()),
-		};
-		debug!("[{}:{}]\n{:#?}", format!("Send {}", msg_type).yellow(), user_id.green(), message);
-		self.adapter.send_message(contact, message).await
-	}
+    pub fn account_info(&self) -> &AccountInfo {
+        &self.account
+    }
+
+    pub async fn send_message(
+        &self,
+        contact: &ContactType<'_>,
+        message: &Message,
+    ) -> puniyu_error::Result<puniyu_adapter_types::SendMsgType> {
+        let (msg_type, user_id) = match contact {
+            ContactType::Friend(friend) => ("PrivateMessage", &friend.peer()),
+            ContactType::Group(group) => ("GroupMssage", &group.peer()),
+            ContactType::GroupTemp(group) => ("Group TempMessage", &group.peer()),
+            ContactType::Guild(guild) => ("GuildMessage", &guild.peer()),
+        };
+        debug!("[{}:{}]\n{:#?}", format!("Send {}", msg_type).yellow(), user_id.green(), message);
+        self.runtime.api().send_message(contact, message).await
+    }
 }
 
 impl std::fmt::Debug for Bot {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Bot")
-			.field("adapter_info", &self.adapter_info())
-			.field("account_info", &self.account_info())
-			.finish()
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Bot")
+            .field("adapter_info", &self.adapter_info())
+            .field("account_info", &self.account_info())
+            .finish()
+    }
 }
 
 impl PartialEq for Bot {
-	fn eq(&self, other: &Self) -> bool {
-		self.adapter_info() == other.adapter_info() && self.account_info() == other.account_info()
-	}
+    fn eq(&self, other: &Self) -> bool {
+        self.adapter_info() == other.adapter_info() && self.account_info() == other.account_info()
+    }
 }

--- a/crates/puniyu_bot/src/macros.rs
+++ b/crates/puniyu_bot/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! register_bot {
         $crate::BotRegistry::register(bot)
     }};
     (adapter: $adapter:expr, account: $account:expr $(,)?) => {{
-        let runtime = $adapter.runtime();
+        let runtime = $crate::AdapterRuntime::new($adapter.info(), $adapter.api());
         $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new(runtime, $account)))
     }};
     (runtime: $runtime:expr, account: $account:expr $(,)?) => {{

--- a/crates/puniyu_bot/src/macros.rs
+++ b/crates/puniyu_bot/src/macros.rs
@@ -6,12 +6,8 @@ macro_rules! register_bot {
         let bot: ::std::sync::Arc<$crate::Bot> = $bot;
         $crate::BotRegistry::register(bot)
     }};
-    (adapter: $adapter:expr, account: $account:expr $(,)?) => {{
-        let runtime = $crate::AdapterRuntime::new($adapter.info(), $adapter.api());
-        $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new(runtime, $account)))
-    }};
-    (runtime: $runtime:expr, account: $account:expr $(,)?) => {{
-        $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new($runtime, $account)))
+    (runtime: $runtime:expr $(,)?) => {{
+        $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new($runtime)))
     }};
 }
 

--- a/crates/puniyu_bot/src/macros.rs
+++ b/crates/puniyu_bot/src/macros.rs
@@ -2,26 +2,23 @@
 ///
 #[macro_export]
 macro_rules! register_bot {
-	(bot: $bot:expr $(,)?) => {{
-		let bot: ::std::sync::Arc<$crate::Bot> = $bot;
-		$crate::BotRegistry::register(bot)
-	}};
-	(adapter: $adapter:expr, account: $account:expr $(,)?) => {{
-		let adapter: ::std::sync::Arc<dyn $crate::AdapterRuntime> = $adapter;
-		let account = $account;
-		$crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new(adapter, account)))
-	}};
-	(runtime: $runtime:expr, account: $account:expr $(,)?) => {{
-		let adapter: ::std::sync::Arc<dyn $crate::AdapterRuntime> = $runtime;
-		let account = $account;
-		$crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new(adapter, account)))
-	}};
+    (bot: $bot:expr $(,)?) => {{
+        let bot: ::std::sync::Arc<$crate::Bot> = $bot;
+        $crate::BotRegistry::register(bot)
+    }};
+    (adapter: $adapter:expr, account: $account:expr $(,)?) => {{
+        let runtime = $adapter.runtime();
+        $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new(runtime, $account)))
+    }};
+    (runtime: $runtime:expr, account: $account:expr $(,)?) => {{
+        $crate::BotRegistry::register(::std::sync::Arc::new($crate::Bot::new($runtime, $account)))
+    }};
 }
 
 /// 按索引或 UIN 注销机器人。
 #[macro_export]
 macro_rules! unregister_bot {
-	($index:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_index($index) }};
-	(index: $index:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_index($index) }};
-	(bot_id: $bot_id:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_bot_id($bot_id) }};
+    ($index:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_index($index) }};
+    (index: $index:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_index($index) }};
+    (bot_id: $bot_id:expr $(,)?) => {{ $crate::BotRegistry::unregister_with_bot_id($bot_id) }};
 }

--- a/crates/puniyu_contact/src/lib.rs
+++ b/crates/puniyu_contact/src/lib.rs
@@ -244,6 +244,30 @@ impl<'c> From<GuildContact<'c>> for ContactType<'c> {
 	}
 }
 
+impl<'c> From<&'c FriendContact<'c>> for ContactType<'c> {
+	fn from(value: &'c FriendContact<'c>) -> Self {
+		Self::Friend(FriendContact::new(value.peer(), value.name()))
+	}
+}
+
+impl<'c> From<&'c GroupContact<'c>> for ContactType<'c> {
+	fn from(value: &'c GroupContact<'c>) -> Self {
+		Self::Group(GroupContact::new(value.peer(), value.name()))
+	}
+}
+
+impl<'c> From<&'c GroupTempContact<'c>> for ContactType<'c> {
+	fn from(value: &'c GroupTempContact<'c>) -> Self {
+		Self::GroupTemp(GroupTempContact::new(value.peer(), value.name()))
+	}
+}
+
+impl<'c> From<&'c GuildContact<'c>> for ContactType<'c> {
+	fn from(value: &'c GuildContact<'c>) -> Self {
+		Self::Guild(GuildContact::new(value.peer(), value.name(), value.sub_name()))
+	}
+}
+
 #[macro_export]
 macro_rules! contact {
 	(Friend, $( $key:ident : $value:expr ),+ $(,)? ) => {

--- a/crates/puniyu_contact/tests/contact_type.rs
+++ b/crates/puniyu_contact/tests/contact_type.rs
@@ -113,3 +113,43 @@ fn test_trait_methods() {
 	assert_eq!(contact.peer(), "123456");
 	assert_eq!(contact.name(), Some("Alice"));
 }
+
+#[test]
+fn test_from_friend_reference() {
+	let friend = FriendContact::new("123456", Some("Alice"));
+	let contact = ContactType::from(&friend);
+
+	assert!(contact.is_friend());
+	assert_eq!(contact.peer(), "123456");
+	assert_eq!(contact.name(), Some("Alice"));
+}
+
+#[test]
+fn test_from_group_reference() {
+	let group = GroupContact::new("789012", Some("Dev Team"));
+	let contact = ContactType::from(&group);
+
+	assert!(contact.is_group());
+	assert_eq!(contact.peer(), "789012");
+	assert_eq!(contact.name(), Some("Dev Team"));
+}
+
+#[test]
+fn test_from_group_temp_reference() {
+	let group_temp = GroupTempContact::new("246810", Some("Temp Team"));
+	let contact = ContactType::from(&group_temp);
+
+	assert!(contact.is_group_temp());
+	assert_eq!(contact.peer(), "246810");
+	assert_eq!(contact.name(), Some("Temp Team"));
+}
+
+#[test]
+fn test_from_guild_reference() {
+	let guild = GuildContact::new("9527", Some("Guild Channel"), Some("General"));
+	let contact = ContactType::from(&guild);
+
+	assert!(contact.is_guild());
+	assert_eq!(contact.peer(), "9527");
+	assert_eq!(contact.name(), Some("Guild Channel"));
+}

--- a/crates/puniyu_context/Cargo.toml
+++ b/crates/puniyu_context/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 [dependencies]
 bytes.workspace = true
 puniyu_account.workspace = true
-puniyu_runtime.workspace = true
 puniyu_adapter_types.workspace = true
+puniyu_adapter_api.workspace = true
 puniyu_bot.workspace = true
 puniyu_sender.workspace = true
 puniyu_error.workspace = true
@@ -27,6 +27,10 @@ puniyu_command_types.workspace = true
 puniyu_event.workspace = true
 puniyu_message.workspace = true
 puniyu_config.workspace = true
+puniyu_runtime.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+puniyu_adapter_api.workspace = true
+puniyu_adapter_core.workspace = true
+puniyu_runtime.workspace = true

--- a/crates/puniyu_context/src/bot.rs
+++ b/crates/puniyu_context/src/bot.rs
@@ -1,42 +1,42 @@
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{AdapterInfo, SendMsgType};
+use puniyu_adapter_api::AdapterApi;
 use puniyu_bot::Bot;
 use puniyu_contact::ContactType;
 use puniyu_message::Message;
-use puniyu_runtime::Runtime;
 
 /// 机器人上下文
 #[derive(Clone, Copy)]
 pub struct BotContext<'c> {
-	inner: &'c Bot,
+    inner: &'c Bot,
 }
 
 impl<'c> BotContext<'c> {
-	pub fn new(bot: &'c Bot) -> Self {
-		Self { inner: bot }
-	}
+    pub fn new(bot: &'c Bot) -> Self {
+        Self { inner: bot }
+    }
 
-	pub fn adapter(&self) -> &AdapterInfo {
-		self.inner.adapter_info()
-	}
+    pub fn api(&self) -> &dyn AdapterApi {
+        self.inner.api()
+    }
 
-	pub fn runtime<T: Runtime>(&self) -> Option<&T> {
-		self.inner.runtime()
-	}
+    pub fn adapter_info(&self) -> &AdapterInfo {
+        self.inner.adapter_info()
+    }
 
-	pub async fn send_message<M>(
-		&self,
-		contact: &ContactType<'_>,
-		message: M,
-	) -> puniyu_error::Result<SendMsgType>
-	where
-		M: Into<Message>,
-	{
-		let message = message.into();
-		self.inner.send_message(contact, &message).await
-	}
+    pub async fn send_message<M>(
+        &self,
+        contact: &ContactType<'_>,
+        message: M,
+    ) -> puniyu_error::Result<SendMsgType>
+    where
+        M: Into<Message>,
+    {
+        let message = message.into();
+        self.inner.send_message(contact, &message).await
+    }
 
-	pub fn account(&self) -> &AccountInfo {
-		self.inner.account_info()
-	}
+    pub fn account(&self) -> &AccountInfo {
+        self.inner.account_info()
+    }
 }

--- a/crates/puniyu_context/src/bot.rs
+++ b/crates/puniyu_context/src/bot.rs
@@ -20,7 +20,7 @@ impl<'c> BotContext<'c> {
         self.inner.api()
     }
 
-    pub fn adapter_info(&self) -> &AdapterInfo {
+    pub fn adapter_info(&self) -> AdapterInfo {
         self.inner.adapter_info()
     }
 
@@ -36,7 +36,7 @@ impl<'c> BotContext<'c> {
         self.inner.send_message(contact, &message).await
     }
 
-    pub fn account(&self) -> &AccountInfo {
+    pub fn account(&self) -> AccountInfo {
         self.inner.account_info()
     }
 }

--- a/crates/puniyu_context/tests/bot_context.rs
+++ b/crates/puniyu_context/tests/bot_context.rs
@@ -5,7 +5,6 @@ use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
 use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
-use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
 use puniyu_context::BotContext;
 use puniyu_message::Message;
@@ -34,38 +33,6 @@ impl OneBotAdapterApi for TestOneBotApi {
 impl Clone for TestOneBotApi {
     fn clone(&self) -> Self {
         Self
-    }
-}
-
-struct TestAdapter {
-    info: AdapterInfo,
-    api: Arc<dyn AdapterApi>,
-}
-
-impl TestAdapter {
-    fn new(info: AdapterInfo) -> Self {
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        Self { info, api }
-    }
-}
-
-impl Clone for TestAdapter {
-    fn clone(&self) -> Self {
-        Self {
-            info: self.info.clone(),
-            api: self.api.clone(),
-        }
-    }
-}
-
-#[async_trait]
-impl Adapter for TestAdapter {
-    fn info(&self) -> AdapterInfo {
-        self.info.clone()
-    }
-
-    fn api(&self) -> Arc<dyn AdapterApi> {
-        self.api.clone()
     }
 }
 

--- a/crates/puniyu_context/tests/bot_context.rs
+++ b/crates/puniyu_context/tests/bot_context.rs
@@ -4,12 +4,15 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_bot::Bot;
 use puniyu_context::BotContext;
 use puniyu_message::Message;
 
-struct TestOneBotApi;
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+    account_info: AccountInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -28,12 +31,9 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
-    }
+    fn adapter_info(&self) -> AdapterInfo { self.adapter_info.clone() }
+    fn account_info(&self) -> AccountInfo { self.account_info.clone() }
 }
 
 fn make_bot_with_account(uin: &str, name: &str, avatar: Bytes) -> Arc<Bot> {
@@ -42,10 +42,11 @@ fn make_bot_with_account(uin: &str, name: &str, avatar: Bytes) -> Arc<Bot> {
         .platform(AdapterPlatform::Other)
         .protocol(AdapterProtocol::Console)
         .build();
-    let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
     let account = AccountInfo { uin: uin.to_string(), name: name.to_string(), avatar };
-    let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
-    Arc::new(Bot::new(runtime, account))
+    let api = Arc::new(TestOneBotApi { adapter_info: info.clone(), account_info: account });
+    let adapter_runtime = puniyu_runtime::AdapterRuntime::new(info);
+    let bot_runtime = puniyu_runtime::BotRuntime::new(adapter_runtime, api);
+    Arc::new(Bot::new(bot_runtime))
 }
 
 #[test]

--- a/crates/puniyu_context/tests/bot_context.rs
+++ b/crates/puniyu_context/tests/bot_context.rs
@@ -3,61 +3,97 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
-use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
-};
+use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
-use puniyu_contact::ContactType;
 use puniyu_context::BotContext;
 use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, SendMessage};
 
-#[derive(Debug)]
-struct TestAdapterRuntime {
-	adapter: AdapterInfo,
+struct TestOneBotApi;
+
+#[async_trait]
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
-impl AdapterProvider for TestAdapterRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.adapter
-	}
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+struct TestAdapter {
+    info: AdapterInfo,
+    api: Arc<dyn AdapterApi>,
+}
+
+impl TestAdapter {
+    fn new(info: AdapterInfo) -> Self {
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        Self { info, api }
+    }
+}
+
+impl Clone for TestAdapter {
+    fn clone(&self) -> Self {
+        Self {
+            info: self.info.clone(),
+            api: self.api.clone(),
+        }
+    }
 }
 
 #[async_trait]
-impl SendMessage for TestAdapterRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl Adapter for TestAdapter {
+    fn info(&self) -> AdapterInfo {
+        self.info.clone()
+    }
+
+    fn api(&self) -> Arc<dyn AdapterApi> {
+        self.api.clone()
+    }
 }
 
 fn make_bot_with_account(uin: &str, name: &str, avatar: Bytes) -> Arc<Bot> {
-	let adapter = adapter_info!(
-		name: "test-adapter",
-		platform: AdapterPlatform::Other,
-		protocol: AdapterProtocol::Console,
-	);
-	let account = AccountInfo { uin: uin.to_string(), name: name.to_string(), avatar };
-	Arc::new(Bot::new(Arc::new(TestAdapterRuntime { adapter }), account))
+    let info = AdapterInfo::builder()
+        .name("test-adapter")
+        .platform(AdapterPlatform::Other)
+        .protocol(AdapterProtocol::Console)
+        .build();
+    let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+    let account = AccountInfo { uin: uin.to_string(), name: name.to_string(), avatar };
+    let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
+    Arc::new(Bot::new(runtime, account))
 }
 
 #[test]
 fn test_bot_context_creation() {
-	let bot = make_bot_with_account("bot123", "TestBot", Bytes::new());
-	let context = BotContext::new(bot.as_ref());
+    let bot = make_bot_with_account("bot123", "TestBot", Bytes::new());
+    let context = BotContext::new(bot.as_ref());
 
-	assert_eq!(context.account().uin, "bot123");
-	assert_eq!(context.account().name, "TestBot");
+    assert_eq!(context.account().uin, "bot123");
+    assert_eq!(context.account().name, "TestBot");
 }
 
 #[test]
 fn test_bot_context_with_avatar() {
-	let bot =
-		make_bot_with_account("bot123", "TestBot", Bytes::from("https://example.com/avatar.jpg"));
-	let context = BotContext::new(bot.as_ref());
+    let bot = make_bot_with_account("bot123", "TestBot", Bytes::from("https://example.com/avatar.jpg"));
+    let context = BotContext::new(bot.as_ref());
 
-	assert_eq!(context.account().avatar, "https://example.com/avatar.jpg");
+    assert_eq!(context.account().avatar, "https://example.com/avatar.jpg");
 }

--- a/crates/puniyu_context/tests/event_context.rs
+++ b/crates/puniyu_context/tests/event_context.rs
@@ -7,7 +7,7 @@ use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
     AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
 use puniyu_contact::{Contact, contact_friend};
@@ -20,7 +20,10 @@ use puniyu_event::{
 use puniyu_message::Message;
 use puniyu_sender::{Sender, sender_friend};
 
-struct TestOneBotApi;
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+    account_info: AccountInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -39,12 +42,9 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
-    }
+    fn adapter_info(&self) -> AdapterInfo { self.adapter_info.clone() }
+    fn account_info(&self) -> AccountInfo { self.account_info.clone() }
 }
 
 struct TestData {
@@ -61,15 +61,16 @@ impl TestData {
             .platform(AdapterPlatform::Other)
             .protocol(AdapterProtocol::Console)
             .build();
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
         let account = AccountInfo {
             uin: "10000".to_string(),
             name: "Puniyu".to_string(),
             avatar: Bytes::new(),
         };
+        let api = Arc::new(TestOneBotApi { adapter_info: info.clone(), account_info: account });
+        let adapter_runtime = puniyu_runtime::AdapterRuntime::new(info);
+        let bot_runtime = puniyu_runtime::BotRuntime::new(adapter_runtime, api);
         Self {
-            bot: Arc::new(Bot::new(runtime, account)),
+            bot: Arc::new(Bot::new(bot_runtime)),
             friend_contact: contact_friend!(peer: "123456", name: "Alice"),
             friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
             elements: Vec::new(),

--- a/crates/puniyu_context/tests/event_context.rs
+++ b/crates/puniyu_context/tests/event_context.rs
@@ -8,7 +8,6 @@ use puniyu_adapter_types::{
     AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
 use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
-use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
 use puniyu_contact::{Contact, contact_friend};
@@ -45,38 +44,6 @@ impl OneBotAdapterApi for TestOneBotApi {
 impl Clone for TestOneBotApi {
     fn clone(&self) -> Self {
         Self
-    }
-}
-
-struct TestAdapter {
-    info: AdapterInfo,
-    api: Arc<dyn AdapterApi>,
-}
-
-impl TestAdapter {
-    fn new(info: AdapterInfo) -> Self {
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        Self { info, api }
-    }
-}
-
-impl Clone for TestAdapter {
-    fn clone(&self) -> Self {
-        Self {
-            info: self.info.clone(),
-            api: self.api.clone(),
-        }
-    }
-}
-
-#[async_trait]
-impl Adapter for TestAdapter {
-    fn info(&self) -> AdapterInfo {
-        self.info.clone()
-    }
-
-    fn api(&self) -> Arc<dyn AdapterApi> {
-        self.api.clone()
     }
 }
 

--- a/crates/puniyu_context/tests/event_context.rs
+++ b/crates/puniyu_context/tests/event_context.rs
@@ -5,114 +5,154 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
+    AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
-use puniyu_contact::{Contact, ContactType, contact_friend};
+use puniyu_contact::{Contact, contact_friend};
 use puniyu_context::EventContext;
 use puniyu_element::receive::Elements;
 use puniyu_event::{
-	Event, EventBase, EventType, SubEventType,
-	message::{FriendMessage, MessageEvent, MessageSubEventType},
+    Event, EventBase, EventType, SubEventType,
+    message::{FriendMessage, MessageEvent, MessageSubEventType},
 };
 use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, SendMessage};
 use puniyu_sender::{Sender, sender_friend};
 
-#[derive(Debug)]
-struct TestAdapterRuntime {
-	adapter: AdapterInfo,
+struct TestOneBotApi;
+
+#[async_trait]
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
-impl AdapterProvider for TestAdapterRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.adapter
-	}
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+struct TestAdapter {
+    info: AdapterInfo,
+    api: Arc<dyn AdapterApi>,
+}
+
+impl TestAdapter {
+    fn new(info: AdapterInfo) -> Self {
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        Self { info, api }
+    }
+}
+
+impl Clone for TestAdapter {
+    fn clone(&self) -> Self {
+        Self {
+            info: self.info.clone(),
+            api: self.api.clone(),
+        }
+    }
 }
 
 #[async_trait]
-impl SendMessage for TestAdapterRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl Adapter for TestAdapter {
+    fn info(&self) -> AdapterInfo {
+        self.info.clone()
+    }
+
+    fn api(&self) -> Arc<dyn AdapterApi> {
+        self.api.clone()
+    }
 }
 
 struct TestData {
-	bot: Arc<Bot>,
-	friend_contact: puniyu_contact::FriendContact<'static>,
-	friend_sender: puniyu_sender::FriendSender<'static>,
-	elements: Vec<Elements<'static>>,
+    bot: Arc<Bot>,
+    friend_contact: puniyu_contact::FriendContact<'static>,
+    friend_sender: puniyu_sender::FriendSender<'static>,
+    elements: Vec<Elements<'static>>,
 }
 
 impl TestData {
-	fn new() -> Self {
-		let adapter = adapter_info!(
-			name: "test-adapter",
-			platform: AdapterPlatform::Other,
-			protocol: AdapterProtocol::Console,
-		);
-		let account = AccountInfo {
-			uin: "10000".to_string(),
-			name: "Puniyu".to_string(),
-			avatar: Bytes::new(),
-		};
-		Self {
-			bot: Arc::new(Bot::new(Arc::new(TestAdapterRuntime { adapter }), account)),
-			friend_contact: contact_friend!(peer: "123456", name: "Alice"),
-			friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
-			elements: Vec::new(),
-		}
-	}
+    fn new() -> Self {
+        let info = AdapterInfo::builder()
+            .name("test-adapter")
+            .platform(AdapterPlatform::Other)
+            .protocol(AdapterProtocol::Console)
+            .build();
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
+        let account = AccountInfo {
+            uin: "10000".to_string(),
+            name: "Puniyu".to_string(),
+            avatar: Bytes::new(),
+        };
+        Self {
+            bot: Arc::new(Bot::new(runtime, account)),
+            friend_contact: contact_friend!(peer: "123456", name: "Alice"),
+            friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
+            elements: Vec::new(),
+        }
+    }
 
-	fn event(&self) -> Event<'_> {
-		Event::Message(Box::new(MessageEvent::Friend(FriendMessage::new(
-			self.bot.as_ref(),
-			"msg-event-1",
-			"123456",
-			&self.friend_contact,
-			&self.friend_sender,
-			1,
-			"msg-1",
-			&self.elements,
-		))))
-	}
+    fn event(&self) -> Event<'_> {
+        Event::Message(Box::new(MessageEvent::Friend(FriendMessage::new(
+            self.bot.as_ref(),
+            "msg-event-1",
+            "123456",
+            &self.friend_contact,
+            &self.friend_sender,
+            1,
+            "msg-1",
+            &self.elements,
+        ))))
+    }
 }
 
 fn base_snapshot<E>(event: &E) -> (u64, String, String, String, String)
 where
-	E: EventBase,
+    E: EventBase,
 {
-	(
-		event.time(),
-		event.event_id().to_string(),
-		event.user_id().to_string(),
-		event.contact().peer().to_string(),
-		event.sender().user_id().to_string(),
-	)
+    (
+        event.time(),
+        event.event_id().to_string(),
+        event.user_id().to_string(),
+        event.contact().peer().to_string(),
+        event.sender().user_id().to_string(),
+    )
 }
 
 #[test]
 fn event_context_implements_event_base() {
-	let data = TestData::new();
-	let event = data.event();
-	let _args = HashMap::<String, ArgValue>::new();
-	let ctx: EventContext<'_> = EventContext::new(&event);
+    let data = TestData::new();
+    let event = data.event();
+    let _args = HashMap::<String, ArgValue>::new();
+    let ctx: EventContext<'_> = EventContext::new(&event);
 
-	assert_eq!(ctx.event_type(), EventType::Message);
-	assert_eq!(ctx.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
-	assert_eq!(
-		base_snapshot(&ctx),
-		(
-			1,
-			"msg-event-1".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-		)
-	);
+    assert_eq!(ctx.event_type(), EventType::Message);
+    assert_eq!(ctx.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
+    assert_eq!(
+        base_snapshot(&ctx),
+        (
+            1,
+            "msg-event-1".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+        )
+    );
 }

--- a/crates/puniyu_context/tests/message_context.rs
+++ b/crates/puniyu_context/tests/message_context.rs
@@ -7,7 +7,7 @@ use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
     AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
 use puniyu_contact::{Contact, contact_friend, contact_group_temp};
@@ -20,7 +20,10 @@ use puniyu_event::{
 use puniyu_message::Message;
 use puniyu_sender::{Sender, SenderType, sender_friend, sender_group_temp};
 
-struct TestOneBotApi;
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+    account_info: AccountInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -39,12 +42,9 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
-    }
+    fn adapter_info(&self) -> AdapterInfo { self.adapter_info.clone() }
+    fn account_info(&self) -> AccountInfo { self.account_info.clone() }
 }
 
 struct TestData {
@@ -63,15 +63,16 @@ impl TestData {
             .platform(AdapterPlatform::Other)
             .protocol(AdapterProtocol::Console)
             .build();
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
         let account = AccountInfo {
             uin: "10000".to_string(),
             name: "Puniyu".to_string(),
             avatar: Bytes::new(),
         };
+        let api = Arc::new(TestOneBotApi { adapter_info: info.clone(), account_info: account });
+        let adapter_runtime = puniyu_runtime::AdapterRuntime::new(info);
+        let bot_runtime = puniyu_runtime::BotRuntime::new(adapter_runtime, api);
         Self {
-            bot: Arc::new(Bot::new(runtime, account)),
+            bot: Arc::new(Bot::new(bot_runtime)),
             friend_contact: contact_friend!(peer: "123456", name: "Alice"),
             friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
             group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),

--- a/crates/puniyu_context/tests/message_context.rs
+++ b/crates/puniyu_context/tests/message_context.rs
@@ -8,7 +8,6 @@ use puniyu_adapter_types::{
     AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
 use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
-use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
 use puniyu_contact::{Contact, contact_friend, contact_group_temp};
@@ -45,38 +44,6 @@ impl OneBotAdapterApi for TestOneBotApi {
 impl Clone for TestOneBotApi {
     fn clone(&self) -> Self {
         Self
-    }
-}
-
-struct TestAdapter {
-    info: AdapterInfo,
-    api: Arc<dyn AdapterApi>,
-}
-
-impl TestAdapter {
-    fn new(info: AdapterInfo) -> Self {
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        Self { info, api }
-    }
-}
-
-impl Clone for TestAdapter {
-    fn clone(&self) -> Self {
-        Self {
-            info: self.info.clone(),
-            api: self.api.clone(),
-        }
-    }
-}
-
-#[async_trait]
-impl Adapter for TestAdapter {
-    fn info(&self) -> AdapterInfo {
-        self.info.clone()
-    }
-
-    fn api(&self) -> Arc<dyn AdapterApi> {
-        self.api.clone()
     }
 }
 

--- a/crates/puniyu_context/tests/message_context.rs
+++ b/crates/puniyu_context/tests/message_context.rs
@@ -5,182 +5,222 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
+    AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_core::Adapter;
 use puniyu_bot::Bot;
 use puniyu_command_types::ArgValue;
-use puniyu_contact::{Contact, ContactType, contact_friend, contact_group_temp};
+use puniyu_contact::{Contact, contact_friend, contact_group_temp};
 use puniyu_context::MessageContext;
 use puniyu_element::receive::{AtElement, Elements, ReplyElement, TextElement};
 use puniyu_event::{
-	EventBase, EventType, SubEventType,
-	message::{FriendMessage, GroupTempMessage, MessageBase, MessageEvent, MessageSubEventType},
+    EventBase, EventType, SubEventType,
+    message::{FriendMessage, GroupTempMessage, MessageBase, MessageEvent, MessageSubEventType},
 };
 use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, SendMessage};
 use puniyu_sender::{Sender, SenderType, sender_friend, sender_group_temp};
 
-#[derive(Debug)]
-struct TestAdapterRuntime {
-	adapter: AdapterInfo,
+struct TestOneBotApi;
+
+#[async_trait]
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
-impl AdapterProvider for TestAdapterRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.adapter
-	}
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+struct TestAdapter {
+    info: AdapterInfo,
+    api: Arc<dyn AdapterApi>,
+}
+
+impl TestAdapter {
+    fn new(info: AdapterInfo) -> Self {
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        Self { info, api }
+    }
+}
+
+impl Clone for TestAdapter {
+    fn clone(&self) -> Self {
+        Self {
+            info: self.info.clone(),
+            api: self.api.clone(),
+        }
+    }
 }
 
 #[async_trait]
-impl SendMessage for TestAdapterRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl Adapter for TestAdapter {
+    fn info(&self) -> AdapterInfo {
+        self.info.clone()
+    }
+
+    fn api(&self) -> Arc<dyn AdapterApi> {
+        self.api.clone()
+    }
 }
 
 struct TestData {
-	bot: Arc<Bot>,
-	friend_contact: puniyu_contact::FriendContact<'static>,
-	friend_sender: puniyu_sender::FriendSender<'static>,
-	group_temp_contact: puniyu_contact::GroupTempContact<'static>,
-	group_temp_sender: puniyu_sender::GroupTempSender<'static>,
-	elements: Vec<Elements<'static>>,
+    bot: Arc<Bot>,
+    friend_contact: puniyu_contact::FriendContact<'static>,
+    friend_sender: puniyu_sender::FriendSender<'static>,
+    group_temp_contact: puniyu_contact::GroupTempContact<'static>,
+    group_temp_sender: puniyu_sender::GroupTempSender<'static>,
+    elements: Vec<Elements<'static>>,
 }
 
 impl TestData {
-	fn new() -> Self {
-		let adapter = adapter_info!(
-			name: "test-adapter",
-			platform: AdapterPlatform::Other,
-			protocol: AdapterProtocol::Console,
-		);
-		let account = AccountInfo {
-			uin: "10000".to_string(),
-			name: "Puniyu".to_string(),
-			avatar: Bytes::new(),
-		};
-		Self {
-			bot: Arc::new(Bot::new(Arc::new(TestAdapterRuntime { adapter }), account)),
-			friend_contact: contact_friend!(peer: "123456", name: "Alice"),
-			friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
-			group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),
-			group_temp_sender: sender_group_temp!(user_id: "123456"),
-			elements: vec![
-				Elements::Text(TextElement::from("hello")),
-				Elements::At(AtElement::from("10000")),
-				Elements::Reply(ReplyElement::from("reply-1")),
-			],
-		}
-	}
+    fn new() -> Self {
+        let info = AdapterInfo::builder()
+            .name("test-adapter")
+            .platform(AdapterPlatform::Other)
+            .protocol(AdapterProtocol::Console)
+            .build();
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
+        let account = AccountInfo {
+            uin: "10000".to_string(),
+            name: "Puniyu".to_string(),
+            avatar: Bytes::new(),
+        };
+        Self {
+            bot: Arc::new(Bot::new(runtime, account)),
+            friend_contact: contact_friend!(peer: "123456", name: "Alice"),
+            friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
+            group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),
+            group_temp_sender: sender_group_temp!(user_id: "123456"),
+            elements: vec![
+                Elements::Text(TextElement::from("hello")),
+                Elements::At(AtElement::from("10000")),
+                Elements::Reply(ReplyElement::from("reply-1")),
+            ],
+        }
+    }
 
-	fn friend_event(&self) -> MessageEvent<'_> {
-		MessageEvent::Friend(FriendMessage::new(
-			self.bot.as_ref(),
-			"msg-event-1",
-			"123456",
-			&self.friend_contact,
-			&self.friend_sender,
-			1,
-			"msg-1",
-			&self.elements,
-		))
-	}
+    fn friend_event(&self) -> MessageEvent<'_> {
+        MessageEvent::Friend(FriendMessage::new(
+            self.bot.as_ref(),
+            "msg-event-1",
+            "123456",
+            &self.friend_contact,
+            &self.friend_sender,
+            1,
+            "msg-1",
+            &self.elements,
+        ))
+    }
 
-	fn group_temp_event(&self) -> MessageEvent<'_> {
-		MessageEvent::GroupTemp(GroupTempMessage::new(
-			self.bot.as_ref(),
-			"msg-event-temp-1",
-			"123456",
-			&self.group_temp_contact,
-			&self.group_temp_sender,
-			2,
-			"msg-temp-1",
-			&self.elements,
-		))
-	}
+    fn group_temp_event(&self) -> MessageEvent<'_> {
+        MessageEvent::GroupTemp(GroupTempMessage::new(
+            self.bot.as_ref(),
+            "msg-event-temp-1",
+            "123456",
+            &self.group_temp_contact,
+            &self.group_temp_sender,
+            2,
+            "msg-temp-1",
+            &self.elements,
+        ))
+    }
 }
 
 fn base_snapshot<E>(event: &E) -> (u64, String, String, String, String)
 where
-	E: EventBase,
+    E: EventBase,
 {
-	(
-		event.time(),
-		event.event_id().to_string(),
-		event.user_id().to_string(),
-		event.contact().peer().to_string(),
-		event.sender().user_id().to_string(),
-	)
+    (
+        event.time(),
+        event.event_id().to_string(),
+        event.user_id().to_string(),
+        event.contact().peer().to_string(),
+        event.sender().user_id().to_string(),
+    )
 }
 
 fn message_summary<M>(message: &M) -> (&str, usize, Vec<&str>, Option<&str>)
 where
-	M: MessageBase,
+    M: MessageBase,
 {
-	(message.message_id(), message.elements().len(), message.get_at(), message.get_reply_id())
+    (message.message_id(), message.elements().len(), message.get_at(), message.get_reply_id())
 }
 
 #[test]
 fn message_context_implements_event_and_message_traits() {
-	let data = TestData::new();
-	let event = data.friend_event();
-	let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
+    let data = TestData::new();
+    let event = data.friend_event();
+    let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
 
-	assert_eq!(ctx.event_type(), EventType::Message);
-	assert_eq!(ctx.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
-	assert_eq!(
-		base_snapshot(&ctx),
-		(
-			1,
-			"msg-event-1".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-		)
-	);
-	assert_eq!(message_summary(&ctx), ("msg-1", 3, vec!["10000"], Some("reply-1")));
+    assert_eq!(ctx.event_type(), EventType::Message);
+    assert_eq!(ctx.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
+    assert_eq!(
+        base_snapshot(&ctx),
+        (
+            1,
+            "msg-event-1".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+        )
+    );
+    assert_eq!(message_summary(&ctx), ("msg-1", 3, vec!["10000"], Some("reply-1")));
 }
 
 #[test]
 fn message_context_inherent_helpers_still_work() {
-	let data = TestData::new();
-	let event = data.friend_event();
-	let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
+    let data = TestData::new();
+    let event = data.friend_event();
+    let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
 
-	assert!(ctx.is_friend());
-	assert!(!ctx.is_group());
-	assert!(!ctx.is_group_temp());
-	assert_eq!(ctx.get_at(), vec!["10000"]);
-	assert!(ctx.mentions_bot());
-	assert_eq!(ctx.get_reply_id(), Some("reply-1"));
-	assert_eq!(ctx.contact().peer(), "123456");
-	assert_eq!(ctx.sender().user_id(), "123456");
+    assert!(ctx.is_friend());
+    assert!(!ctx.is_group());
+    assert!(!ctx.is_group_temp());
+    assert_eq!(ctx.get_at(), vec!["10000"]);
+    assert!(ctx.mentions_bot());
+    assert_eq!(ctx.get_reply_id(), Some("reply-1"));
+    assert_eq!(ctx.contact().peer(), "123456");
+    assert_eq!(ctx.sender().user_id(), "123456");
 }
 
 #[test]
 fn group_temp_message_context_helpers_work() {
-	let data = TestData::new();
-	let event = data.group_temp_event();
-	let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
+    let data = TestData::new();
+    let event = data.group_temp_event();
+    let ctx = MessageContext::new(&event, HashMap::<String, ArgValue>::new());
 
-	assert!(!ctx.is_friend());
-	assert!(!ctx.is_group());
-	assert!(ctx.is_group_temp());
-	assert!(ctx.as_group().is_none());
-	assert!(ctx.as_group_temp().is_some());
-	assert_eq!(ctx.contact().peer(), "654321");
-	assert!(ctx.contact().is_group_temp());
-	assert_eq!(
-		match ctx.sender() {
-			SenderType::Friend(_) => "friend",
-			SenderType::Group(_) => "group",
-			SenderType::GroupTemp(_) => "grouptemp",
-			SenderType::Guild(_) => "guild",
-		},
-		"grouptemp"
-	);
+    assert!(!ctx.is_friend());
+    assert!(!ctx.is_group());
+    assert!(ctx.is_group_temp());
+    assert!(ctx.as_group().is_none());
+    assert!(ctx.as_group_temp().is_some());
+    assert_eq!(ctx.contact().peer(), "654321");
+    assert!(ctx.contact().is_group_temp());
+    assert_eq!(
+        match ctx.sender() {
+            SenderType::Friend(_) => "friend",
+            SenderType::Group(_) => "group",
+            SenderType::GroupTemp(_) => "grouptemp",
+            SenderType::Guild(_) => "guild",
+        },
+        "grouptemp"
+    );
 }

--- a/crates/puniyu_core/Cargo.toml
+++ b/crates/puniyu_core/Cargo.toml
@@ -36,6 +36,7 @@ puniyu_contact.workspace = true
 puniyu_segment.workspace = true
 puniyu_version.workspace = true
 puniyu_sender.workspace = true
+puniyu_runtime.workspace = true
 
 puniyu_error = { workspace = true, features = ["registry"] }
 puniyu_command = { workspace = true, features = ["registry"] }

--- a/crates/puniyu_core/src/app/adapter.rs
+++ b/crates/puniyu_core/src/app/adapter.rs
@@ -2,18 +2,14 @@ use std::sync::Arc;
 
 use puniyu_adapter_core::Adapter;
 use puniyu_adapter_core::AdapterRegistry;
-use puniyu_bot::{Bot, BotRegistry};
 use puniyu_common::source::SourceType;
 use puniyu_error::Result;
-use puniyu_path::adapter::*;
-use puniyu_runtime::AdapterRuntime;
 use puniyu_version::VERSION;
-use tokio::fs::create_dir_all;
 
 use crate::logger::core_warn;
 
 pub async fn init_adapter(adapter: Arc<dyn Adapter>) -> Result {
-    let name = adapter.info().name.clone();
+    let name = adapter.name().to_string();
     let core_version = adapter.core_version();
     if core_version > VERSION {
         core_warn!(
@@ -25,16 +21,6 @@ pub async fn init_adapter(adapter: Arc<dyn Adapter>) -> Result {
         return Ok(());
     }
 
-    init_dir(config_dir().join(&name), &name, "config").await?;
-    init_dir(data_dir().join(&name), &name, "data").await?;
-    init_dir(resource_dir().join(&name), &name, "resource").await?;
-    init_dir(temp_dir().join(&name), &name, "temp").await?;
-
-    adapter.on_load().await.map_err(|e| {
-        std::io::Error::other(format!("Failed to on_load adapter {}: {}", name, e))
-    })?;
-    super::config::init_config(&name, adapter.config()).await?;
-
     let index =
         AdapterRegistry::register(Arc::clone(&adapter)).unwrap_or_else(|e| {
             panic!("Failed to register adapter {}: {}", name, e)
@@ -43,26 +29,10 @@ pub async fn init_adapter(adapter: Arc<dyn Adapter>) -> Result {
 
     register_adapter_components(index, source, adapter.server()).await;
 
-    let runtime = AdapterRuntime::new(adapter.info(), adapter.api());
-    for account in adapter.accounts() {
-        let bot = Arc::new(Bot::new(runtime.clone(), account));
-        if let Err(e) = BotRegistry::register(bot) {
-            log::error!("[{}] Failed to register bot: {}", name, e);
-        }
-    }
+    adapter.on_load().await.map_err(|e| {
+        std::io::Error::other(format!("Failed to on_load adapter {}: {}", name, e))
+    })?;
 
-    Ok(())
-}
-
-async fn init_dir(path: std::path::PathBuf, adapter_name: &str, dir_kind: &str) -> Result {
-    if !path.exists() {
-        create_dir_all(&path).await.map_err(|e| {
-            std::io::Error::other(format!(
-                "Failed to create {} dir for adapter {}: {}",
-                dir_kind, adapter_name, e
-            ))
-        })?;
-    }
     Ok(())
 }
 

--- a/crates/puniyu_core/src/app/adapter.rs
+++ b/crates/puniyu_core/src/app/adapter.rs
@@ -1,76 +1,79 @@
+use std::sync::Arc;
+
 use puniyu_adapter_core::Adapter;
 use puniyu_adapter_core::AdapterRegistry;
 use puniyu_bot::{Bot, BotRegistry};
 use puniyu_common::source::SourceType;
 use puniyu_error::Result;
 use puniyu_path::adapter::*;
+use puniyu_runtime::AdapterRuntime;
 use puniyu_version::VERSION;
-use std::{io::Error as IoError, sync::Arc};
 use tokio::fs::create_dir_all;
 
 use crate::logger::core_warn;
 
 pub async fn init_adapter(adapter: Arc<dyn Adapter>) -> Result {
-	let name = adapter.runtime().adapter_info().name.clone();
-	let core_version = adapter.core_version();
-	if core_version <= VERSION {
-		core_warn!(
-			"{} ({}): adapter core version is too low, please upgrade to {} or higher",
-			name,
-			core_version,
-			VERSION
-		);
-		return Ok(());
-	}
+    let name = adapter.info().name.clone();
+    let core_version = adapter.core_version();
+    if core_version <= VERSION {
+        core_warn!(
+            "{} ({}): adapter core version is too low, please upgrade to {} or higher",
+            name,
+            core_version,
+            VERSION
+        );
+        return Ok(());
+    }
 
-	init_dir(config_dir().join(&name), &name, "config").await?;
-	init_dir(data_dir().join(&name), &name, "data").await?;
-	init_dir(resource_dir().join(&name), &name, "resource").await?;
-	init_dir(temp_dir().join(&name), &name, "temp").await?;
+    init_dir(config_dir().join(&name), &name, "config").await?;
+    init_dir(data_dir().join(&name), &name, "data").await?;
+    init_dir(resource_dir().join(&name), &name, "resource").await?;
+    init_dir(temp_dir().join(&name), &name, "temp").await?;
 
-	adapter
-		.on_load()
-		.await
-		.map_err(|e| IoError::other(format!("Failed to on_load adapter {}: {}", name, e)))?;
-	super::config::init_config(&name, adapter.config()).await?;
+    adapter.on_load().await.map_err(|e| {
+        std::io::Error::other(format!("Failed to on_load adapter {}: {}", name, e))
+    })?;
+    super::config::init_config(&name, adapter.config()).await?;
 
-	let index = AdapterRegistry::register(Arc::clone(&adapter))
-		.unwrap_or_else(|e| panic!("Failed to register adapter {}: {}", name, e));
-	let source = SourceType::Adapter(index);
+    let index =
+        AdapterRegistry::register(Arc::clone(&adapter)).unwrap_or_else(|e| {
+            panic!("Failed to register adapter {}: {}", name, e)
+        });
+    let source = SourceType::Adapter(index);
 
-	register_adapter_components(index, source, adapter.server()).await;
+    register_adapter_components(index, source, adapter.server()).await;
 
-	let runtime = adapter.runtime();
-	for account in adapter.accounts() {
-		let bot = Arc::new(Bot::new(Arc::clone(&runtime), account));
-		if let Err(e) = BotRegistry::register(bot) {
-			log::error!("[{}] Failed to register bot: {}", name, e);
-		}
-	}
+    let runtime = AdapterRuntime::new(adapter.info(), adapter.api());
+    for account in adapter.accounts() {
+        let bot = Arc::new(Bot::new(runtime.clone(), account));
+        if let Err(e) = BotRegistry::register(bot) {
+            log::error!("[{}] Failed to register bot: {}", name, e);
+        }
+    }
 
-	Ok(())
+    Ok(())
 }
 
 async fn init_dir(path: std::path::PathBuf, adapter_name: &str, dir_kind: &str) -> Result {
-	if !path.exists() {
-		create_dir_all(&path).await.map_err(|e| {
-			IoError::other(format!(
-				"Failed to create {} dir for adapter {}: {}",
-				dir_kind, adapter_name, e
-			))
-		})?;
-	}
-	Ok(())
+    if !path.exists() {
+        create_dir_all(&path).await.map_err(|e| {
+            std::io::Error::other(format!(
+                "Failed to create {} dir for adapter {}: {}",
+                dir_kind, adapter_name, e
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 async fn register_adapter_components(
-	adapter_id: u64,
-	source: SourceType,
-	server: Option<puniyu_server::ServerFunction>,
+    adapter_id: u64,
+    source: SourceType,
+    server: Option<puniyu_server::ServerFunction>,
 ) {
-	if let Some(server) = server {
-		super::server::init_server(source, server).unwrap_or_else(|e| {
-			panic!("Failed to init server for adapter {}: {:?}", adapter_id, e)
-		});
-	}
+    if let Some(server) = server {
+        super::server::init_server(source, server).unwrap_or_else(|e| {
+            panic!("Failed to init server for adapter {}: {:?}", adapter_id, e)
+        });
+    }
 }

--- a/crates/puniyu_core/src/app/adapter.rs
+++ b/crates/puniyu_core/src/app/adapter.rs
@@ -15,9 +15,9 @@ use crate::logger::core_warn;
 pub async fn init_adapter(adapter: Arc<dyn Adapter>) -> Result {
     let name = adapter.info().name.clone();
     let core_version = adapter.core_version();
-    if core_version <= VERSION {
+    if core_version > VERSION {
         core_warn!(
-            "{} ({}): adapter core version is too low, please upgrade to {} or higher",
+            "{}: adapter requires framework version >= {}, but current version is {}",
             name,
             core_version,
             VERSION

--- a/crates/puniyu_core/src/app/plugin.rs
+++ b/crates/puniyu_core/src/app/plugin.rs
@@ -15,9 +15,9 @@ use crate::logger::core_warn;
 pub async fn init_plugin(plugin: Arc<dyn Plugin>) -> Result {
 	let name = plugin.name();
 	let core_version = plugin.core_version();
-	if core_version <= VERSION {
+	if core_version > VERSION {
 		core_warn!(
-			"{} ({}): plugin core version is too low, please upgrade to {} or higher",
+			"{}: plugin requires framework version >= {}, but current version is {}",
 			name,
 			core_version,
 			VERSION

--- a/crates/puniyu_core/src/lib.rs
+++ b/crates/puniyu_core/src/lib.rs
@@ -3,11 +3,8 @@ mod common;
 mod logger;
 pub use app::App;
 
-pub mod adapter {
-	pub use puniyu_adapter_core::*;
-	pub use puniyu_adapter_types::*;
-}
 pub use puniyu_api::account;
+pub use puniyu_api::adapter;
 pub use puniyu_api::bot;
 pub use puniyu_api::command;
 pub use puniyu_api::config;
@@ -17,6 +14,7 @@ pub use puniyu_api::element;
 pub use puniyu_api::event;
 pub use puniyu_api::message;
 pub use puniyu_api::path;
+pub use puniyu_api::plugin;
 pub use puniyu_api::result;
 pub use puniyu_api::runtime;
 pub use puniyu_api::segment;
@@ -25,9 +23,7 @@ pub use puniyu_api::server;
 pub use puniyu_api::task;
 pub use puniyu_api::{app_name, app_version};
 pub use puniyu_api::{pkg_name, pkg_version};
-pub use puniyu_plugin_core as plugin;
 pub use puniyu_semver::Version;
-
 
 pub use puniyu_api::async_trait;
 pub use puniyu_api::inventory;

--- a/crates/puniyu_event/Cargo.toml
+++ b/crates/puniyu_event/Cargo.toml
@@ -22,6 +22,7 @@ puniyu_bot.workspace = true
 puniyu_contact.workspace = true
 puniyu_sender.workspace = true
 puniyu_element.workspace = true
+puniyu_adapter_api.workspace = true
 
 derive_more = { workspace = true, features = ["display", "debug", "from"] }
 
@@ -30,6 +31,8 @@ puniyu_error.workspace = true
 async-trait.workspace = true
 serde_json.workspace = true
 puniyu_account.workspace = true
-puniyu_runtime.workspace = true
+puniyu_adapter_api.workspace = true
+puniyu_adapter_core.workspace = true
 puniyu_adapter_types.workspace = true
 puniyu_message.workspace = true
+puniyu_runtime.workspace = true

--- a/crates/puniyu_event/src/message.rs
+++ b/crates/puniyu_event/src/message.rs
@@ -262,7 +262,7 @@ macro_rules! codegen_message {
 			fn event_id(&self) -> &str { self.event_id }
 			fn sub_event(&self) -> $crate::SubEventType { $crate::SubEventType::Message($sub_event) }
 			fn bot(&self) -> &puniyu_bot::Bot { self.bot }
-			fn self_id(&self) -> &str { self.bot.account_info().uin.as_str() }
+			fn self_id(&self) -> &str { self.bot.self_id() }
 			fn user_id(&self) -> &str { self.user_id }
 			fn contact(&self) -> puniyu_contact::ContactType<'_> { self.contact.clone().into() }
 			fn sender(&self) -> puniyu_sender::SenderType<'_> { self.sender.clone().into() }

--- a/crates/puniyu_event/tests/event.rs
+++ b/crates/puniyu_event/tests/event.rs
@@ -3,186 +3,196 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
-use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
-};
+use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
 use puniyu_bot::Bot;
-use puniyu_contact::{Contact, ContactType, contact_friend};
+use puniyu_contact::{Contact, contact_friend};
 use puniyu_element::receive::Elements;
 use puniyu_event::{
-	Event, EventType, SubEventType,
-	extension::{ExtensionEvent, NoticeSubEventType},
-	message::{FriendMessage, MessageEvent, MessageSubEventType},
+    Event, EventType, SubEventType,
+    extension::{ExtensionEvent, NoticeSubEventType},
+    message::{FriendMessage, MessageEvent, MessageSubEventType},
 };
 use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, SendMessage};
 use puniyu_sender::{Sender, sender_friend};
 
-#[derive(Debug)]
-struct TestAdapterRuntime {
-	adapter: AdapterInfo,
-}
-
-impl AdapterProvider for TestAdapterRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.adapter
-	}
-}
+struct TestOneBotApi;
 
 #[async_trait]
-impl SendMessage for TestAdapterRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+
 struct TestData {
-	bot: Arc<Bot>,
-	friend_contact: puniyu_contact::FriendContact<'static>,
-	friend_sender: puniyu_sender::FriendSender<'static>,
-	elements: Vec<Elements<'static>>,
+    bot: Arc<Bot>,
+    friend_contact: puniyu_contact::FriendContact<'static>,
+    friend_sender: puniyu_sender::FriendSender<'static>,
+    elements: Vec<Elements<'static>>,
 }
 
 impl TestData {
-	fn new() -> Self {
-		let adapter = adapter_info!("console", AdapterPlatform::QQ, AdapterProtocol::Console);
-		let account = AccountInfo {
-			uin: "10000".to_string(),
-			name: "Puniyu".to_string(),
-			avatar: Bytes::new(),
-		};
-		Self {
-			bot: Arc::new(Bot::new(Arc::new(TestAdapterRuntime { adapter }), account)),
-			friend_contact: contact_friend!(peer: "123456", name: "Alice"),
-			friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
-			elements: Vec::new(),
-		}
-	}
+    fn new() -> Self {
+        let info = AdapterInfo::builder()
+            .name("console")
+            .platform(AdapterPlatform::QQ)
+            .protocol(AdapterProtocol::Console)
+            .build();
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
+        let account = AccountInfo {
+            uin: "10000".to_string(),
+            name: "Puniyu".to_string(),
+            avatar: Bytes::new(),
+        };
+        Self {
+            bot: Arc::new(Bot::new(runtime, account)),
+            friend_contact: contact_friend!(peer: "123456", name: "Alice"),
+            friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
+            elements: Vec::new(),
+        }
+    }
 
-	fn message_event(&self) -> Event<'_> {
-		Event::Message(Box::new(MessageEvent::Friend(FriendMessage::new(
-			self.bot.as_ref(),
-			"msg-event-1",
-			"123456",
-			&self.friend_contact,
-			&self.friend_sender,
-			1,
-			"msg-1",
-			&self.elements,
-		))))
-	}
+    fn message_event(&self) -> Event<'_> {
+        Event::Message(Box::new(MessageEvent::Friend(FriendMessage::new(
+            self.bot.as_ref(),
+            "msg-event-1",
+            "123456",
+            &self.friend_contact,
+            &self.friend_sender,
+            1,
+            "msg-1",
+            &self.elements,
+        ))))
+    }
 
-	fn extension_event(&self) -> Event<'_> {
-		Event::Extension(Box::new(TestExtensionEvent {
-			bot: Arc::clone(&self.bot),
-			contact: self.friend_contact.clone(),
-			sender: self.friend_sender.clone(),
-		}))
-	}
+    fn extension_event(&self) -> Event<'_> {
+        Event::Extension(Box::new(TestExtensionEvent {
+            bot: Arc::clone(&self.bot),
+            contact: self.friend_contact.clone(),
+            sender: self.friend_sender.clone(),
+        }))
+    }
 }
 
 fn event_snapshot(event: &Event<'_>) -> (u64, String, String, String, String) {
-	(
-		event.time(),
-		event.event_id().to_string(),
-		event.user_id().to_string(),
-		event.contact().peer().to_string(),
-		event.sender().user_id().to_string(),
-	)
+    (
+        event.time(),
+        event.event_id().to_string(),
+        event.user_id().to_string(),
+        event.contact().peer().to_string(),
+        event.sender().user_id().to_string(),
+    )
 }
 
 pub struct TestExtensionEvent {
-	bot: Arc<Bot>,
-	contact: puniyu_contact::FriendContact<'static>,
-	sender: puniyu_sender::FriendSender<'static>,
+    bot: Arc<Bot>,
+    contact: puniyu_contact::FriendContact<'static>,
+    sender: puniyu_sender::FriendSender<'static>,
 }
 
 impl puniyu_event::EventBase for TestExtensionEvent {
-	fn time(&self) -> u64 {
-		2
-	}
-	fn event_type(&self) -> puniyu_event::EventType {
-		puniyu_event::EventType::Extension
-	}
-	fn event_id(&self) -> &str {
-		"ext-event-1"
-	}
-	fn sub_event(&self) -> puniyu_event::SubEventType {
-		self.r#type()
-	}
-	fn bot(&self) -> &Bot {
-		self.bot.as_ref()
-	}
-	fn self_id(&self) -> &str {
-		self.bot.account_info().uin.as_str()
-	}
-	fn user_id(&self) -> &str {
-		"123456"
-	}
-	fn contact(&self) -> puniyu_contact::ContactType<'_> {
-		self.contact.clone().into()
-	}
-	fn sender(&self) -> puniyu_sender::SenderType<'_> {
-		self.sender.clone().into()
-	}
+    fn time(&self) -> u64 {
+        2
+    }
+    fn event_type(&self) -> puniyu_event::EventType {
+        puniyu_event::EventType::Extension
+    }
+    fn event_id(&self) -> &str {
+        "ext-event-1"
+    }
+    fn sub_event(&self) -> puniyu_event::SubEventType {
+        self.r#type()
+    }
+    fn bot(&self) -> &Bot {
+        self.bot.as_ref()
+    }
+    fn self_id(&self) -> &str {
+        self.bot.account_info().uin.as_str()
+    }
+    fn user_id(&self) -> &str {
+        "123456"
+    }
+    fn contact(&self) -> puniyu_contact::ContactType<'_> {
+        self.contact.clone().into()
+    }
+    fn sender(&self) -> puniyu_sender::SenderType<'_> {
+        self.sender.clone().into()
+    }
 }
 
 impl ExtensionEvent for TestExtensionEvent {
-	fn r#type(&self) -> SubEventType {
-		SubEventType::Notice(NoticeSubEventType::new("friend_poke"))
-	}
+    fn r#type(&self) -> SubEventType {
+        SubEventType::Notice(NoticeSubEventType::new("friend_poke"))
+    }
 
-	fn content(&self) -> &str {
-		"Alice poked the bot"
-	}
+    fn content(&self) -> &str {
+        "Alice poked the bot"
+    }
 }
 
 #[test]
 fn root_event_message_helpers_work() {
-	let data = TestData::new();
-	let event = data.message_event();
+    let data = TestData::new();
+    let event = data.message_event();
 
-	assert!(event.as_message().is_some());
-	assert_eq!(event.event_type(), EventType::Message);
-	assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
-	assert_eq!(
-		event_snapshot(&event),
-		(
-			1,
-			"msg-event-1".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-		)
-	);
+    assert!(event.as_message().is_some());
+    assert_eq!(event.event_type(), EventType::Message);
+    assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
+    assert_eq!(
+        event_snapshot(&event),
+        (
+            1,
+            "msg-event-1".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+        )
+    );
 }
 
 #[test]
 fn root_event_extension_helpers_work() {
-	let data = TestData::new();
-	let event = data.extension_event();
+    let data = TestData::new();
+    let event = data.extension_event();
 
-	assert!(event.as_message().is_none());
-	assert!(event.as_extension().is_some());
-	assert_eq!(event.event_type(), EventType::Extension);
-	assert_eq!(event.sub_event(), SubEventType::Notice(NoticeSubEventType::new("friend_poke")));
-	assert_eq!(
-		event.as_extension().unwrap().r#type(),
-		SubEventType::Notice(NoticeSubEventType::new("friend_poke"))
-	);
-	assert_eq!(event.as_extension().unwrap().content(), "Alice poked the bot");
-	assert_eq!(
-		event_snapshot(&event),
-		(
-			2,
-			"ext-event-1".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-		)
-	);
+    assert!(event.as_message().is_none());
+    assert!(event.as_extension().is_some());
+    assert_eq!(event.event_type(), EventType::Extension);
+    assert_eq!(event.sub_event(), SubEventType::Notice(NoticeSubEventType::new("friend_poke")));
+    assert_eq!(
+        event.as_extension().unwrap().r#type(),
+        SubEventType::Notice(NoticeSubEventType::new("friend_poke"))
+    );
+    assert_eq!(event.as_extension().unwrap().content(), "Alice poked the bot");
+    assert_eq!(
+        event_snapshot(&event),
+        (
+            2,
+            "ext-event-1".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+        )
+    );
 }

--- a/crates/puniyu_event/tests/event.rs
+++ b/crates/puniyu_event/tests/event.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType};
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_bot::Bot;
 use puniyu_contact::{Contact, contact_friend};
 use puniyu_element::receive::Elements;
@@ -16,7 +16,10 @@ use puniyu_event::{
 use puniyu_message::Message;
 use puniyu_sender::{Sender, sender_friend};
 
-struct TestOneBotApi;
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+    account_info: AccountInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -35,12 +38,9 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
-    }
+    fn adapter_info(&self) -> AdapterInfo { self.adapter_info.clone() }
+    fn account_info(&self) -> AccountInfo { self.account_info.clone() }
 }
 
 
@@ -58,15 +58,16 @@ impl TestData {
             .platform(AdapterPlatform::QQ)
             .protocol(AdapterProtocol::Console)
             .build();
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
         let account = AccountInfo {
             uin: "10000".to_string(),
             name: "Puniyu".to_string(),
             avatar: Bytes::new(),
         };
+        let api = Arc::new(TestOneBotApi { adapter_info: info.clone(), account_info: account });
+        let adapter_runtime = puniyu_runtime::AdapterRuntime::new(info);
+        let bot_runtime = puniyu_runtime::BotRuntime::new(adapter_runtime, api);
         Self {
-            bot: Arc::new(Bot::new(runtime, account)),
+            bot: Arc::new(Bot::new(bot_runtime)),
             friend_contact: contact_friend!(peer: "123456", name: "Alice"),
             friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
             elements: Vec::new(),
@@ -128,7 +129,7 @@ impl puniyu_event::EventBase for TestExtensionEvent {
         self.bot.as_ref()
     }
     fn self_id(&self) -> &str {
-        self.bot.account_info().uin.as_str()
+        self.bot.self_id()
     }
     fn user_id(&self) -> &str {
         "123456"

--- a/crates/puniyu_event/tests/event_trait_impls.rs
+++ b/crates/puniyu_event/tests/event_trait_impls.rs
@@ -6,7 +6,7 @@ use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
     AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
-use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
+use puniyu_adapter_api::OneBotAdapterApi;
 use puniyu_bot::Bot;
 use puniyu_contact::{Contact, contact_friend, contact_group_temp};
 use puniyu_element::receive::Elements;
@@ -17,7 +17,10 @@ use puniyu_event::{
 use puniyu_message::Message;
 use puniyu_sender::{Sender, SenderType, sender_friend, sender_group_temp};
 
-struct TestOneBotApi;
+struct TestOneBotApi {
+    adapter_info: AdapterInfo,
+    account_info: AccountInfo,
+}
 
 #[async_trait]
 impl OneBotAdapterApi for TestOneBotApi {
@@ -36,14 +39,10 @@ impl OneBotAdapterApi for TestOneBotApi {
     ) -> puniyu_error::Result<SendMsgType> {
         Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
     }
-}
 
-impl Clone for TestOneBotApi {
-    fn clone(&self) -> Self {
-        Self
-    }
+    fn adapter_info(&self) -> AdapterInfo { self.adapter_info.clone() }
+    fn account_info(&self) -> AccountInfo { self.account_info.clone() }
 }
-
 
 
 struct TestData {
@@ -62,15 +61,16 @@ impl TestData {
             .platform(AdapterPlatform::QQ)
             .protocol(AdapterProtocol::Console)
             .build();
-        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
-        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
         let account = AccountInfo {
             uin: "10000".to_string(),
             name: "Puniyu".to_string(),
             avatar: Bytes::new(),
         };
+        let api = Arc::new(TestOneBotApi { adapter_info: info.clone(), account_info: account });
+        let adapter_runtime = puniyu_runtime::AdapterRuntime::new(info);
+        let bot_runtime = puniyu_runtime::BotRuntime::new(adapter_runtime, api);
         Self {
-            bot: Arc::new(Bot::new(runtime, account)),
+            bot: Arc::new(Bot::new(bot_runtime)),
             friend_contact: contact_friend!(peer: "123456", name: "Alice"),
             friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
             group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),

--- a/crates/puniyu_event/tests/event_trait_impls.rs
+++ b/crates/puniyu_event/tests/event_trait_impls.rs
@@ -4,161 +4,174 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use puniyu_account::AccountInfo;
 use puniyu_adapter_types::{
-	AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType, adapter_info,
+    AdapterInfo, AdapterPlatform, AdapterProtocol, SendMsgType,
 };
+use puniyu_adapter_api::{AdapterApi, OneBotAdapterApi};
 use puniyu_bot::Bot;
-use puniyu_contact::{Contact, ContactType, contact_friend, contact_group_temp};
+use puniyu_contact::{Contact, contact_friend, contact_group_temp};
 use puniyu_element::receive::Elements;
 use puniyu_event::{
-	EventBase, EventType, SubEventType,
-	message::{FriendMessage, GroupTempMessage, MessageBase, MessageEvent, MessageSubEventType},
+    EventBase, EventType, SubEventType,
+    message::{FriendMessage, GroupTempMessage, MessageBase, MessageEvent, MessageSubEventType},
 };
 use puniyu_message::Message;
-use puniyu_runtime::{AdapterProvider, SendMessage};
 use puniyu_sender::{Sender, SenderType, sender_friend, sender_group_temp};
 
-#[derive(Debug)]
-struct TestAdapterRuntime {
-	adapter: AdapterInfo,
-}
-
-impl AdapterProvider for TestAdapterRuntime {
-	fn adapter_info(&self) -> &AdapterInfo {
-		&self.adapter
-	}
-}
+struct TestOneBotApi;
 
 #[async_trait]
-impl SendMessage for TestAdapterRuntime {
-	async fn send_message(
-		&self,
-		_contact: &ContactType<'_>,
-		_message: &Message,
-	) -> puniyu_error::Result<SendMsgType> {
-		Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
-	}
+impl OneBotAdapterApi for TestOneBotApi {
+    async fn send_private_msg(
+        &self,
+        _user_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
+
+    async fn send_group_msg(
+        &self,
+        _group_id: u64,
+        _message: &Message,
+    ) -> puniyu_error::Result<SendMsgType> {
+        Ok(SendMsgType { message_id: "test-msg".to_string(), time: std::time::Duration::ZERO })
+    }
 }
 
+impl Clone for TestOneBotApi {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+
+
 struct TestData {
-	bot: Arc<Bot>,
-	friend_contact: puniyu_contact::FriendContact<'static>,
-	friend_sender: puniyu_sender::FriendSender<'static>,
-	group_temp_contact: puniyu_contact::GroupTempContact<'static>,
-	group_temp_sender: puniyu_sender::GroupTempSender<'static>,
-	elements: Vec<Elements<'static>>,
+    bot: Arc<Bot>,
+    friend_contact: puniyu_contact::FriendContact<'static>,
+    friend_sender: puniyu_sender::FriendSender<'static>,
+    group_temp_contact: puniyu_contact::GroupTempContact<'static>,
+    group_temp_sender: puniyu_sender::GroupTempSender<'static>,
+    elements: Vec<Elements<'static>>,
 }
 
 impl TestData {
-	fn new() -> Self {
-		let adapter = adapter_info!("console", AdapterPlatform::QQ, AdapterProtocol::Console);
-		let account = AccountInfo {
-			uin: "10000".to_string(),
-			name: "Puniyu".to_string(),
-			avatar: Bytes::new(),
-		};
-		Self {
-			bot: Arc::new(Bot::new(Arc::new(TestAdapterRuntime { adapter }), account)),
-			friend_contact: contact_friend!(peer: "123456", name: "Alice"),
-			friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
-			group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),
-			group_temp_sender: sender_group_temp!(user_id: "123456"),
-			elements: Vec::new(),
-		}
-	}
+    fn new() -> Self {
+        let info = AdapterInfo::builder()
+            .name("console")
+            .platform(AdapterPlatform::QQ)
+            .protocol(AdapterProtocol::Console)
+            .build();
+        let api = Arc::new(TestOneBotApi) as Arc<dyn AdapterApi>;
+        let runtime = puniyu_runtime::AdapterRuntime::new(info, api);
+        let account = AccountInfo {
+            uin: "10000".to_string(),
+            name: "Puniyu".to_string(),
+            avatar: Bytes::new(),
+        };
+        Self {
+            bot: Arc::new(Bot::new(runtime, account)),
+            friend_contact: contact_friend!(peer: "123456", name: "Alice"),
+            friend_sender: sender_friend!(user_id: "123456", nick: "Alice"),
+            group_temp_contact: contact_group_temp!(peer: "654321", name: "Temp Group"),
+            group_temp_sender: sender_group_temp!(user_id: "123456"),
+            elements: Vec::new(),
+        }
+    }
 
-	fn friend_event(&self) -> MessageEvent<'_> {
-		MessageEvent::Friend(FriendMessage::new(
-			self.bot.as_ref(),
-			"msg-event-1",
-			"123456",
-			&self.friend_contact,
-			&self.friend_sender,
-			1,
-			"msg-1",
-			&self.elements,
-		))
-	}
+    fn friend_event(&self) -> MessageEvent<'_> {
+        MessageEvent::Friend(FriendMessage::new(
+            self.bot.as_ref(),
+            "msg-event-1",
+            "123456",
+            &self.friend_contact,
+            &self.friend_sender,
+            1,
+            "msg-1",
+            &self.elements,
+        ))
+    }
 
-	fn group_temp_event(&self) -> MessageEvent<'_> {
-		MessageEvent::GroupTemp(GroupTempMessage::new(
-			self.bot.as_ref(),
-			"msg-event-temp-1",
-			"123456",
-			&self.group_temp_contact,
-			&self.group_temp_sender,
-			2,
-			"msg-temp-1",
-			&self.elements,
-		))
-	}
+    fn group_temp_event(&self) -> MessageEvent<'_> {
+        MessageEvent::GroupTemp(GroupTempMessage::new(
+            self.bot.as_ref(),
+            "msg-event-temp-1",
+            "123456",
+            &self.group_temp_contact,
+            &self.group_temp_sender,
+            2,
+            "msg-temp-1",
+            &self.elements,
+        ))
+    }
 }
 
 fn base_snapshot<E>(event: &E) -> (u64, String, String, String, String)
 where
-	E: EventBase,
+    E: EventBase,
 {
-	(
-		event.time(),
-		event.event_id().to_string(),
-		event.user_id().to_string(),
-		event.contact().peer().to_string(),
-		event.sender().user_id().to_string(),
-	)
+    (
+        event.time(),
+        event.event_id().to_string(),
+        event.user_id().to_string(),
+        event.contact().peer().to_string(),
+        event.sender().user_id().to_string(),
+    )
 }
 
 fn message_summary<M>(message: &M) -> (&str, usize)
 where
-	M: MessageBase,
+    M: MessageBase,
 {
-	(message.message_id(), message.elements().len())
+    (message.message_id(), message.elements().len())
 }
 
 #[test]
 fn message_event_implements_event_and_message_traits() {
-	let data = TestData::new();
-	let event = data.friend_event();
+    let data = TestData::new();
+    let event = data.friend_event();
 
-	assert_eq!(event.event_type(), EventType::Message);
-	assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
-	assert_eq!(
-		base_snapshot(&event),
-		(
-			1,
-			"msg-event-1".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-			"123456".to_string(),
-		)
-	);
-	assert_eq!(message_summary(&event), ("msg-1", 0));
+    assert_eq!(event.event_type(), EventType::Message);
+    assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::Friend));
+    assert_eq!(
+        base_snapshot(&event),
+        (
+            1,
+            "msg-event-1".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+            "123456".to_string(),
+        )
+    );
+    assert_eq!(message_summary(&event), ("msg-1", 0));
 }
 
 #[test]
 fn group_temp_message_event_implements_event_and_message_traits() {
-	let data = TestData::new();
-	let event = data.group_temp_event();
+    let data = TestData::new();
+    let event = data.group_temp_event();
 
-	assert_eq!(event.event_type(), EventType::Message);
-	assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::GroupTemp));
-	assert_eq!(
-		base_snapshot(&event),
-		(
-			2,
-			"msg-event-temp-1".to_string(),
-			"123456".to_string(),
-			"654321".to_string(),
-			"123456".to_string(),
-		)
-	);
-	assert_eq!(message_summary(&event), ("msg-temp-1", 0));
-	assert_eq!(
-		match event.sender() {
-			SenderType::Friend(_) => "friend",
-			SenderType::Group(_) => "group",
-			SenderType::GroupTemp(_) => "grouptemp",
-			SenderType::Guild(_) => "guild",
-		},
-		"grouptemp"
-	);
-	assert!(event.as_group_temp().is_some());
+    assert_eq!(event.event_type(), EventType::Message);
+    assert_eq!(event.sub_event(), SubEventType::Message(MessageSubEventType::GroupTemp));
+    assert_eq!(
+        base_snapshot(&event),
+        (
+            2,
+            "msg-event-temp-1".to_string(),
+            "123456".to_string(),
+            "654321".to_string(),
+            "123456".to_string(),
+        )
+    );
+    assert_eq!(message_summary(&event), ("msg-temp-1", 0));
+    assert_eq!(
+        match event.sender() {
+            SenderType::Friend(_) => "friend",
+            SenderType::Group(_) => "group",
+            SenderType::GroupTemp(_) => "grouptemp",
+            SenderType::Guild(_) => "guild",
+        },
+        "grouptemp"
+    );
+    assert!(event.as_group_temp().is_some());
 }

--- a/crates/puniyu_runtime/Cargo.toml
+++ b/crates/puniyu_runtime/Cargo.toml
@@ -11,12 +11,12 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait.workspace = true
 actix-web.workspace = true
 tokio = { workspace = true, features = ["rt"] }
 puniyu_error.workspace = true
 puniyu_account.workspace = true
 puniyu_adapter_types.workspace = true
+puniyu_adapter_api.workspace = true
 puniyu_contact.workspace = true
 puniyu_message.workspace = true
 

--- a/crates/puniyu_runtime/src/lib.rs
+++ b/crates/puniyu_runtime/src/lib.rs
@@ -5,32 +5,64 @@
 //! ## 提供内容
 //!
 //! - [`AdapterRuntime`]：适配器级运行时结构体
+//! - [`BotRuntime`]：Bot 级运行时结构体
 //! - `ServerRuntime`：HTTP 服务运行句柄
 //!
 //! ## 设计说明
 //!
-//! 通过结构体代替 trait object，提供编译期类型安全和优化。
+//! 运行时仅做结构组合，元信息从 API 获取。
+
 mod server;
 #[doc(inline)]
 pub use server::ServerRuntime;
+
 use std::sync::Arc;
-
-use puniyu_adapter_types::AdapterInfo;
+use puniyu_account::AccountInfo;
 use puniyu_adapter_api::AdapterApi;
+use puniyu_adapter_types::AdapterInfo;
 
+/// 适配器级运行时（所有 Bot 共享）。
+///
+/// 仅承载适配器元信息，作为 `BotRuntime` 的共享组合层。
 #[derive(Clone)]
 pub struct AdapterRuntime {
     info: AdapterInfo,
-    api: Arc<dyn AdapterApi>,
 }
 
 impl AdapterRuntime {
-    pub fn new(info: AdapterInfo, api: Arc<dyn AdapterApi>) -> Self {
-        Self { info, api }
+    pub fn new(info: AdapterInfo) -> Self {
+        Self { info }
     }
 
     pub fn info(&self) -> &AdapterInfo {
         &self.info
+    }
+}
+
+/// Bot 级运行时（每个账号独立）。
+///
+/// 组合适配器运行时与 per-account API，是 `Bot` 的核心数据结构。
+#[derive(Clone)]
+pub struct BotRuntime {
+    adapter: AdapterRuntime,
+    api: Arc<dyn AdapterApi>,
+}
+
+impl BotRuntime {
+    pub fn new(adapter: AdapterRuntime, api: Arc<dyn AdapterApi>) -> Self {
+        Self { adapter, api }
+    }
+
+    pub fn adapter_info(&self) -> AdapterInfo {
+        self.api.adapter_info()
+    }
+
+    pub fn adapter_runtime(&self) -> &AdapterRuntime {
+        &self.adapter
+    }
+
+    pub fn account_info(&self) -> AccountInfo {
+        self.api.account_info()
     }
 
     pub fn api(&self) -> &dyn AdapterApi {

--- a/crates/puniyu_runtime/src/lib.rs
+++ b/crates/puniyu_runtime/src/lib.rs
@@ -2,61 +2,38 @@
 //!
 //! puniyu 的统一运行时抽象与运行时句柄定义。
 //!
-//! 该 crate 主要提供两类能力：
-//! - 运行时 trait 抽象，用于描述适配器、Bot 与消息发送等通用能力
-//! - 运行时句柄类型，用于管理框架内部的异步运行单元
-//!
 //! ## 提供内容
 //!
-//! - [`Runtime`]：运行时基础 trait，提供只读运行时访问视图
-//! - [`AdapterProvider`]：访问适配器信息
-//! - [`AdapterRuntime`]：适配器级运行时抽象
-//! - [`SendMessage`]：发送消息能力 trait
-//! - [`ServerRuntime`]：HTTP 服务运行句柄，封装服务停止与等待结束等生命周期能力
+//! - [`AdapterRuntime`]：适配器级运行时结构体
+//! - `ServerRuntime`：HTTP 服务运行句柄
 //!
 //! ## 设计说明
 //!
-//! trait 抽象主要服务于上层业务与插件系统，便于以统一接口访问运行时能力；
-//! 具体句柄类型则用于承载框架内部异步任务的生命周期管理。
+//! 通过结构体代替 trait object，提供编译期类型安全和优化。
 mod server;
 #[doc(inline)]
 pub use server::ServerRuntime;
-use std::any::Any;
+use std::sync::Arc;
 
-use async_trait::async_trait;
-use puniyu_adapter_types::{AdapterInfo, SendMsgType};
-use puniyu_contact::ContactType;
-use puniyu_error::Result;
-use puniyu_message::Message;
+use puniyu_adapter_types::AdapterInfo;
+use puniyu_adapter_api::AdapterApi;
 
-pub trait Runtime: Any + Send + Sync {}
-
-impl dyn Runtime {
-	pub fn as_any(&self) -> &dyn Any {
-		self
-	}
-
-	pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-		self.as_any().downcast_ref::<T>()
-	}
+#[derive(Clone)]
+pub struct AdapterRuntime {
+    info: AdapterInfo,
+    api: Arc<dyn AdapterApi>,
 }
 
-pub trait AdapterProvider: Send + Sync {
-	fn adapter_info(&self) -> &AdapterInfo;
-}
+impl AdapterRuntime {
+    pub fn new(info: AdapterInfo, api: Arc<dyn AdapterApi>) -> Self {
+        Self { info, api }
+    }
 
-pub trait AdapterRuntime: Runtime + AdapterProvider + SendMessage {}
+    pub fn info(&self) -> &AdapterInfo {
+        &self.info
+    }
 
-
-impl<T> AdapterRuntime for T where T: Runtime + AdapterProvider + SendMessage {}
-
-impl<T: 'static> Runtime for T where T: AdapterProvider + SendMessage {}
-
-#[async_trait]
-pub trait SendMessage: Send + Sync {
-	async fn send_message(
-		&self,
-		contact: &ContactType<'_>,
-		message: &Message,
-	) -> Result<SendMsgType>;
+    pub fn api(&self) -> &dyn AdapterApi {
+        &*self.api
+    }
 }


### PR DESCRIPTION
- 新增puniyu_adapter_api模块，定义统一的适配器API trait
- 实现OneBot协议API trait及对应的通用send_message方法
- 重构Adapter trait接口，将runtime方法改为info和api方法
- 更新Bot结构体，使用新的API接口发送消息
- 在多个模块中添加对新适配器API的依赖引用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 统一并升级适配器与运行时接口，简化 Bot/上下文 的运行时交互与消息转发路径。
* **新特性**
  * 暴露统一的适配器 API，使消息发送与适配器信息查询更一致。
* **测试**
  * 更新并新增多处适配器/上下文相关测试，覆盖新接口与行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/puniyu/core/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->